### PR TITLE
Adds get_diffraction_pattern to allow the viewing of diffraction simulations

### DIFF
--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -115,7 +115,7 @@ class DiffractionSimulation:
     def intensities(self, intensities):
         self._intensities = intensities
     
-    def get_diffraction_pattern(sim,size=512,sigma=10):
+    def get_diffraction_pattern(self,size=512,sigma=10):
         """Returns the diffraction data as a numpy array with
         two-dimensional Gaussians representing each diffracted peak. Should only
         be used for qualitative work.
@@ -139,11 +139,11 @@ class DiffractionSimulation:
         produces reasonably good patterns when the lattice parameters are on
         the order of 0.5nm and a the default size and sigma are used.
         """
-        side_length = np.min(np.multiply((size/2),sim.calibration))
-        mask_for_sides = np.abs(sim.coordinates[:, 0:2]) < side_length
+        side_length = np.min(np.multiply((size/2),self.calibration))
+        mask_for_sides = np.any((np.abs(self.coordinates[:, 0:2]) < side_length),axis=1)
 
-        spot_coords = np.add(sim.calibrated_coordinates[mask_for_sides],size/2).astype(int)
-        spot_intens = sim.intensities[mask_for_sides]
+        spot_coords = np.add(self.calibrated_coordinates[mask_for_sides],size/2).astype(int)
+        spot_intens = self.intensities[mask_for_sides]
         pattern = np.zeros([size, size])
         pattern[spot_coords[:,0],spot_coords[:,1]] = spot_intens
         pattern = ndi.gaussian_filter(pattern,sigma)

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -18,6 +18,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import ndimage as ndi
 
 
 class DiffractionSimulation:
@@ -113,7 +114,41 @@ class DiffractionSimulation:
     @intensities.setter
     def intensities(self, intensities):
         self._intensities = intensities
+    
+    def get_diffraction_pattern(sim,size=512,sigma=10):
+        """Returns the diffraction data as a numpy array with
+        two-dimensional Gaussians representing each diffracted peak. Should only
+        be used for qualitative work.
 
+        Parameters
+        ----------
+        size  : int
+            The size of a side length (in pixels)
+
+        sigma : float
+            Standard deviation of the Gaussian function to be plotted (in pixels).
+
+        Returns
+        -------
+        diffraction-pattern : numpy.array
+            The simulated electron diffraction pattern, normalised.
+
+        Notes
+        -----
+        If don't know the exact calibration of your diffraction signal using 1e-2
+        produces reasonably good patterns when the lattice parameters are on
+        the order of 0.5nm and a the default size and sigma are used.
+        """
+        side_length = np.min(np.multiply((size/2),sim.calibration))
+        mask_for_sides = np.abs(sim.coordinates[:, 0:2]) < side_length
+
+        spot_coords = np.add(sim.calibrated_coordinates[mask_for_sides],size/2).astype(int)
+        spot_intens = sim.intensities[mask_for_sides]
+        pattern = np.zeros([size, size])
+        pattern[spot_coords[:,0],spot_coords[:,1]] = spot_intens
+        pattern = ndi.gaussian_filter(pattern,sigma)
+
+        return np.divide(pattern,np.max(pattern))
 
 class ProfileSimulation:
     """Holds the result of a given kinematic simulation of a diffraction profile

--- a/diffsims/tests/test_sims/test_diffraction_simulation.py
+++ b/diffsims/tests/test_sims/test_diffraction_simulation.py
@@ -137,5 +137,9 @@ class TestDiffractionSimulation:
         diffraction_simulation.offset = offset
         assert np.allclose(diffraction_simulation.calibrated_coordinates, expected)
 
-    def test_assertion_free_get_diffraction_pattern(self,diffraction_simulation):
-        z = diffraction_simulation.get_diffraction_pattern()
+    def test_assertion_free_get_diffraction_pattern(self):
+        short_sim =  DiffractionSimulation(coordinates=np.asarray([[0.3, 1.2, 0]]),
+                          intensities=np.ones(1),
+                          calibration=[1, 2])
+
+        z = short_sim.get_diffraction_pattern()

--- a/diffsims/tests/test_sims/test_diffraction_simulation.py
+++ b/diffsims/tests/test_sims/test_diffraction_simulation.py
@@ -136,3 +136,6 @@ class TestDiffractionSimulation:
         diffraction_simulation.calibration = calibration
         diffraction_simulation.offset = offset
         assert np.allclose(diffraction_simulation.calibrated_coordinates, expected)
+
+    def test_assertion_free_get_diffraction_pattern(self,diffraction_simulation):
+        z = diffraction_simulation.get_diffraction_pattern()


### PR DESCRIPTION
---
name: Adds get_diffraction_pattern to allow the viewing of diffraction simulations
about: Similar to the old `.as_signal()` this is a `numpy/scipy` only implementation that turns a list of coordinates and intensities from a diffraction simulation into a pattern that can be `imshow`(ed)

- [x] ready for review and merge?
---

**Release Notes**
> major
> new feature 
Summary: Introduces `get_diffraction_pattern` method

**What does this PR do? Please describe and/or link to an open issue.**
on running the `.get_diffraction_pattern()` method, a pattern will be produced. With the default arguments the pattern will be 512x512, with a 10px sigma value for each spot. Be aware that at present a user has to select the correct size from which the calibration was defined to get patterns that look like experimental data.


