### PR TITLE
Correcting to right multiply for diffpy

### DIFF
--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -357,7 +357,7 @@ def simulate_rotated_structure(diffraction_generator, structure, rotation_matrix
     structure : diffpy.structure.Structure
         Structure object to simulate
     rotation_matrix : ndarray
-        3x3 matrix describing the base rotation to apply to the structure
+        3x3 matrix describing the base rotation to apply to the structure, applied on the left of the vector
     reciprocal_radius : float
         The maximum g-vector magnitude to be included in the simulations.
     with_direct_beam : bool
@@ -368,9 +368,14 @@ def simulate_rotated_structure(diffraction_generator, structure, rotation_matrix
     simulation : DiffractionSimulation
         The simulation data generated from the given structure and rotation.
     """
+    # Convert left multiply (input) to right multiply (diffpy)
+    stdbase = structure.lattice.stdbase
+    stdbase_inverse = np.linalg.inv(stdbase)
+    rotation_matrix_diffpy = stdbase_inverse @ rotation_matrix @ stdbase
+    
     lattice_rotated = diffpy.structure.lattice.Lattice(
         *structure.lattice.abcABG(),
-        baserot=rotation_matrix)
+        baserot=rotation_matrix_diffpy)
     # Don't change the original
     structure_rotated = diffpy.structure.Structure(structure)
     structure_rotated.placeInLattice(lattice_rotated)


### PR DESCRIPTION
---
name: Correcting to right multiply for diffpy
about: This is a bugfix for #28 

---

**Release Notes**
> major 
> improvement / bugfix 

**What does this PR do? Please describe and/or link to an open issue.**

As detailed in the associated issue, diffpy provides a rotation of the form:
`Ans = std @ BR  (1)`
where std is a known 3x3 matrix and BR is a user defined 3 by 3 matrix. Our code works on the assumption that a solution of the form
`Ans = Rotation @ Basis (2) `

To tie these two ends together we set 
`BR = std^{-1} @ Rotation @ std`
which when subbed into equation (1) produces
`Ans = (std @ std^{-1}) @ Rotation @ std`
which corresponds with (2) 