### PR TITLE
Bugfix for beam direction grid generation (INCORRECT)

### DIFF
--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -118,10 +118,15 @@ def get_grid_around_beam_direction(beam_direction,resolution, angular_range=(0, 
     rotation_alpha, rotation_beta = _get_rotation_to_beam_direction(beam_direction)
     # see _create_advanced_linearly_spaced_array_in_rzxz for details
     steps_gamma = int(np.ceil((angular_range[1] - angular_range[0])/resolution))
+
     alpha = np.asarray([rotation_alpha])
     beta =  np.asarray([rotation_beta])
     gamma = np.linspace(angular_range[0],angular_range[1], num=steps_gamma, endpoint=False)
-    z = np.asarray(list(product(alpha, beta, gamma)))
+
+    agamma = np.asarray(list(product(alpha,gamma)))
+    bgamma = np.asarray(list(product(beta,gamma)))
+    z = np.hstack((agamma[:,0].reshape((-1,1)),bgamma))
+
     raw_grid = Euler(z, axis_convention='szxz') #we make use of an uncommon euler angle set here for speed
     grid_rzxz = raw_grid.to_AxAngle().to_Euler(axis_convention='rzxz')
     rotation_list = grid_rzxz.to_rotation_list(round_to=2)

--- a/diffsims/utils/rotation_conversion_utils.py
+++ b/diffsims/utils/rotation_conversion_utils.py
@@ -37,6 +37,7 @@ Finally - two classes, Euler & AxAngle are provided
 """
 
 import numpy as np
+import warnings
 
 def vectorised_euler2quat(eulers, axes='rzxz'):
     """ Applies the transformation that takes eulers to quaternions
@@ -493,6 +494,8 @@ class Euler():
             raise ValueError("Your data is not in the correct shape")
         if np.any(self.data[:] > 360):
             raise ValueError("Some of your angles are greater 360")
+        if np.all(np.abs(self.data[:]) < 2*np.pi)
+            warnings.warn("Your angles all seem quite small, are you sure you're not in radians?")
 
         return None
 


### PR DESCRIPTION
---
name: Bugfix for beam direction grid generation (INCORRECT)
about: 

- [ ] ready for review and merge?
---

**Release Notes**
> minor
>bugfix 
Summary: n/a (correction to previously unreleased functionality)

**What does this PR do? Please describe and/or link to an open issue.**
So, this function is broken if rotation_alpha or rotation_beta is an array, but that's never the input. This PR remains a good landing point for the place where I discovered this problem though so I'll leave and close it.


Old version

```
import numpy as np
from itertools import product

alpha = np.asarray([1,2])
beta =  np.asarray([3,4])
gamma = np.asarray([5,6,7])

z = np.asarray(list(product(alpha, beta, gamma)))

array([[1, 3, 5],
       [1, 3, 6],
       [1, 3, 7],
       [1, 4, 5],
       [1, 4, 6],
       [1, 4, 7],
       [2, 3, 5],
       [2, 3, 6],
       [2, 3, 7],
       [2, 4, 5],
       [2, 4, 6],
       [2, 4, 7]])

```

New version
```
import numpy as np
from itertools import product

alpha = np.asarray([1,2])
beta =  np.asarray([3,4])
gamma = np.asarray([5,6,7])

agamma = np.asarray(list(product(alpha,gamma)))
bgamma = np.asarray(list(product(beta,gamma)))
z = np.hstack((agamma[:,0].reshape((-1,1)),bgamma))

array([[1, 3, 5],
       [1, 3, 6],
       [1, 3, 7],
       [2, 4, 5],
       [2, 4, 6],
       [2, 4, 7]])
```