### PR TITLE
Syntax change to avoid (erronous) divide by zero warnings

### DIFF
--- a/diffsims/utils/gridding_utils.py
+++ b/diffsims/utils/gridding_utils.py
@@ -272,8 +272,12 @@ def beam_directions_to_euler_angles(points_in_cartesians):
          The appropriate euler angles
     """
     axes = np.cross([0,0,1],points_in_cartesians) #in unit cartesians so this is fine, [0,0,1] returns [0,0,0]
-    angle = np.arcsin(np.linalg.norm(axes,axis=1))
-    normalised_axes = np.where(angle.reshape(-1,1) > 0, np.divide(axes,np.linalg.norm(axes,axis=1).reshape(-1,1)), axes)
+    norms = np.linalg.norm(axes,axis=1).reshape(-1,1)
+    angle = np.arcsin(norms)
+
+    normalised_axes = np.ones_like(axes)
+    np.divide(axes,norms,out=normalised_axes,where=norms!=0)
+
     np_axangles = np.hstack((normalised_axes,angle.reshape((-1,1))))
     eulers = AxAngle(np_axangles).to_Euler(axis_convention='rzxz')
     return eulers


### PR DESCRIPTION
---
name: Syntax change to avoid (erronous) divide by zero warnings
about: -


---

**Release Notes**
> 0.2.0
> bugfix 
Summary: Internal changes

**What does this PR do? Please describe and/or link to an open issue.**
See https://stackoverflow.com/questions/14861891/runtimewarning-invalid-value-encountered-in-divide

While using `np.where()` does avoid the infinities from a divide by zero, internally the code still attempts to `/0` so a warning is raised. With this new syntax that doesn't happen. External behavior remains unchanged.