### PR TITLE
Bugfixes for fundamental zone functionality

### DIFF
--- a/diffsims/tests/test_generators/test_rotation_list_generator.py
+++ b/diffsims/tests/test_generators/test_rotation_list_generator.py
@@ -39,7 +39,11 @@ def test_get_grid_around_beam_direction():
 
 @pytest.mark.parametrize("space_group_number",[1,3,30,190,215,229])
 def test_get_fundemental_zone_grid(space_group_number):
-    grid = get_fundemental_zone_grid(space_group_number,resolution=3)
+    grid_narrow = get_fundemental_zone_grid(space_group_number,resolution=6)
+    grid_wide = get_fundemental_zone_grid(space_group_number,resolution=12)
+    assert (len(grid_narrow)/len(grid_wide)) > (2**3) - 1 #lower bounds
+    assert (len(grid_narrow)/len(grid_wide)) < (2**3) + 1 #upper bounds
+
 
 def test_get_grid_streographic():
     grid = get_grid_streographic('tetragonal',1,equal='angle')

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -36,9 +36,21 @@ def sparse_rzxz_grid():
 
 def assert_volume_changes_obeyed(r,start_size,volume):
     """
+    Confirms that 'r' is within 10% of the predicted size based on theory [1]
 
+    Parameters
+    ----------
+    r : np.array [n,4]
+        Kept orientations in r-frank representation
+    start_size : int
+        The number of elements originally considered
+    volume : float
+        The fraction of axis-angle space volume occupied by the target zone
+
+    Notes
+    -----
+    [1] Page 103 - Orientations and Rotations - A. Morawiec
     """
-
     assert r.data.shape[0] > 0
     assert r.data.shape[0] < (start_size*volume*1.1)
     assert r.data.shape[0] > (start_size*volume*0.9)
@@ -54,40 +66,42 @@ def test_select_fundemental_zone():
 
 @pytest.mark.parametrize("point_group_str",['432','222','23','1'])
 def test_remove_out_of_domain_rotations(sparse_rzxz_grid,point_group_str):
+    """ Tests that cutting rotations bigger than a certain angle behaves as expected"""
     start_size = sparse_rzxz_grid.data.shape[0]
     ax = remove_out_of_domain_rotations(sparse_rzxz_grid,point_group_str)
+    assert ax.data.shape[0] > 0
+
     if point_group_str == '432':
-        assert ax.data.shape[0] > 0
         assert ax.data.shape[0] < (start_size/2)
     elif point_group_str == '222' or point_group_str == '23':
-        assert ax.data.shape[0] > 0
         assert ax.data.shape[0] < (start_size*0.8)
     elif point_group_str == '1':
         assert start_size == ax.data.shape[0]
 
 @pytest.mark.parametrize("point_group_str",['2','222','23','432'])
 def test_generate_mask_from_rodrigues_frank(sparse_rzxz_grid,point_group_str):
+    """ Tests that mask generation from rf parameterizations behaves as hoped """
     start_size = sparse_rzxz_grid.data.shape[0]
     mask = generate_mask_from_rodrigues_frank(sparse_rzxz_grid,point_group_str)
+    assert np.sum(mask) > 0
+
     if point_group_str == '2':
-        assert np.sum(mask) > 0
         assert np.sum(mask) > (start_size/2.2)
         assert np.sum(mask) < (start_size/1.8)
     elif point_group_str == '432':
-            assert np.sum(mask) > 0
             assert np.sum(mask) < (start_size/2)
     elif point_group_str == '222' or point_group_str == '23':
-            assert np.sum(mask) > 0
             assert np.sum(mask) < (start_size*0.8)
 
 @pytest.mark.xfail(strict=True)
 def test_edge_case_numpy_bounding_plane():
+    """ Confirms you can't have infinite bounding planes """
     z = np.asarray([1,1,1,np.inf])
     numpy_bounding_plane(data=z,vector=[1,1,1],distance=1)
 
-""" Broad test that the code runs """
 @pytest.mark.parametrize("fz_string", ['1', '2', '222', '3', '32', '6', '622', '4', '422', '432', '23'])
 def test_non_zero_returns(sparse_rzxz_grid,fz_string):
+    """ All code paths must return some orientations """
     reduced_data = reduce_to_fundemental_zone(sparse_rzxz_grid,fz_string)
     assert reduced_data.data.shape[0] > 0
 
@@ -95,17 +109,17 @@ def test_non_zero_returns(sparse_rzxz_grid,fz_string):
 
 @pytest.mark.parametrize("order",[1,2,3,4,6])
 def test_cyclic(order):
-    """ Uniform spacing in angle space """
-    axis = np.hstack((np.zeros((2000,2)),np.ones((2000,1))))
-    rf = np.tan(np.linspace(0,np.pi/2,2000))
+    """ For z axis rotations, included size scaling should go with 'order' """
+    axis = np.hstack((np.zeros((2000,2)),np.ones((2000,1)))) # z
+    rf = np.tan(np.linspace(0,np.pi/2,2000)) #Uniform spacing in angle space
     z = np.hstack((axis,rf.reshape(-1,1)))
     reduced = cyclic_group(z,order)
     assert np.allclose(np.sum(reduced),2000/order,atol=3)
 
 @pytest.mark.parametrize("fz_string",['1','2','3','4','6'])
 def test_orthogonal_linear_case_for_cyclic_group(fz_string):
-    """ Rotations about x feel no effect of the cyclic group """
-    axis = np.hstack((np.ones((2000,1)),np.zeros((2000,2))))
+    """ Rotations about the x direction are never removed by the effects of the cyclic group """
+    axis = np.hstack((np.ones((2000,1)),np.zeros((2000,2)))) # x
     angle = np.linspace(-np.pi,np.pi,2000)
     along_x_axis = AxAngle(np.hstack((axis,angle.reshape(-1,1))))
     reduced = reduce_to_fundemental_zone(along_x_axis,fz_string)
@@ -113,6 +127,7 @@ def test_orthogonal_linear_case_for_cyclic_group(fz_string):
 
 @pytest.mark.parametrize("order",['1','2','3','4','6'])
 def test_cyclic_groups(sparse_rzxz_grid,order):
+    """ Asserts volume changes broadly as expected """
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,order)
     volume = 1/int(order)
@@ -123,7 +138,7 @@ def test_cyclic_groups(sparse_rzxz_grid,order):
 
 @pytest.mark.parametrize("order",[2,3,4,6])
 def test_x_direction_dihedral(order):
-    """ Uniform spacing in angle space """
+    """ All dihedral groups have the same effect on x-rotations """
     axis = np.hstack((np.ones((2000,1)),np.zeros((2000,2))))
     rf = np.tan(np.linspace(0,np.pi/2,2000))
     z = np.hstack((axis,rf.reshape(-1,1)))
@@ -132,6 +147,7 @@ def test_x_direction_dihedral(order):
 
 @pytest.mark.parametrize("point_group_str",['222', '32', '422', '622'])
 def test_dihedral_groups(sparse_rzxz_grid,point_group_str):
+    """ Asserts volume changes broadly as expected """
     order = int(point_group_str[0])
     volume = 1 / (2*order) # From page 103 of Morawiec
     start_size = sparse_rzxz_grid.data.shape[0]
@@ -147,10 +163,10 @@ def dense_rzxz_grid():
     return axangle
 
 def test_tetragonal_group(dense_rzxz_grid):
+    """ Tests volume lies with the two bounding spheres """
     full_volume  = (4/3) * np.pi * (180)**3
     outer_volume = (4/3) * np.pi * (90)**3
-    #https://en.wikipedia.org/wiki/Octahedron
-    r_inner = 90 * np.sqrt(1/3)
+    r_inner = 90 * np.sqrt(1/3) # See https://en.wikipedia.org/wiki/Octahedron
     inner_volume = (4/3) * np.pi * (r_inner)**3
     start_size = dense_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(dense_rzxz_grid,'23')

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -95,7 +95,7 @@ def test_non_zero_returns(sparse_rzxz_grid,fz_string):
 
 @pytest.mark.parametrize("order",[1,2,3,4,6])
 def test_cyclic(order):
-    """ Uniform spacing in RF """
+    """ Uniform spacing in angle space """
     axis = np.hstack((np.zeros((2000,2)),np.ones((2000,1))))
     rf = np.tan(np.linspace(0,np.pi/2,2000))
     z = np.hstack((axis,rf.reshape(-1,1)))
@@ -123,7 +123,7 @@ def test_cyclic_groups(sparse_rzxz_grid,order):
 
 @pytest.mark.parametrize("order",[2,3,4,6])
 def test_x_direction_dihedral(order):
-    """ Uniform spacing in RF """
+    """ Uniform spacing in angle space """
     axis = np.hstack((np.ones((2000,1)),np.zeros((2000,2))))
     rf = np.tan(np.linspace(0,np.pi/2,2000))
     z = np.hstack((axis,rf.reshape(-1,1)))

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -34,6 +34,15 @@ def sparse_rzxz_grid():
     axangle = z.to_AxAngle()
     return axangle
 
+def assert_volume_changes_obeyed(r,start_size,volume):
+    """
+
+    """
+
+    assert r.data.shape[0] > 0
+    assert r.data.shape[0] < (start_size*volume*1.1)
+    assert r.data.shape[0] > (start_size*volume*0.9)
+
 """ Tests of internal functionality """
 
 def test_select_fundemental_zone():
@@ -106,9 +115,9 @@ def test_orthogonal_linear_case_for_cyclic_group(fz_string):
 def test_cyclic_groups(sparse_rzxz_grid,order):
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,order)
-    assert r.data.shape[0] > 0
-    assert r.data.shape[0] > (start_size/(1.1*int(order)))
-    assert r.data.shape[0] < (start_size/(0.9*int(order)))
+    volume = 1/int(order)
+    assert_volume_changes_obeyed(r,start_size,volume)
+
 
 """ Dihedral case """
 
@@ -127,9 +136,7 @@ def test_dihedral_groups(sparse_rzxz_grid,point_group_str):
     volume = 1 / (2*order) # From page 103 of Morawiec
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,point_group_str)
-    assert r.data.shape[0] > 0
-    assert r.data.shape[0] > (start_size * volume * 0.9)
-    assert r.data.shape[0] < (start_size * volume * 1.1)
+    assert_volume_changes_obeyed(r,start_size,volume)
 
 """ Cubic cases """
 
@@ -137,14 +144,10 @@ def test_tetragonal_group(sparse_rzxz_grid):
     volume = 1 / (12) # From "On three dimensional misorientation spaces"
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,'23')
-    assert r.data.shape[0] > 0
-    assert r.data.shape[0] > (start_size * volume * 0.9)
-    assert r.data.shape[0] < (start_size * volume * 1.1)
+    assert_volume_changes_obeyed(r,start_size,volume)
 
 def test_octahedral_group(sparse_rzxz_grid):
     volume = 1 / (24) # From "On three dimensional misorientation spaces"
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,'432')
-    assert r.data.shape[0] > 0
-    assert r.data.shape[0] > (start_size * volume * 0.9)
-    assert r.data.shape[0] < (start_size * volume * 1.1)
+    assert_volume_changes_obeyed(r,start_size,volume)

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -19,16 +19,100 @@
 import pytest
 import numpy as np
 
-from diffsims.utils.fundemental_zone_utils import get_proper_point_group_string, reduce_to_fundemental_zone, numpy_bounding_plane
+from diffsims.utils.fundemental_zone_utils import get_proper_point_group_string, reduce_to_fundemental_zone, numpy_bounding_plane, cyclic_group
+from diffsims.utils.gridding_utils import create_linearly_spaced_array_in_rzxz
+from diffsims.utils.rotation_conversion_utils import Euler,AxAngle
 
 """ These tests check the fundemental_zone section of the code """
 
+@pytest.fixture()
+def fairly_dense_rzxz_grid():
+    z = create_linearly_spaced_array_in_rzxz(1)
+    axangle = z.to_AxAngle()
+    return axangle
+
+@pytest.fixture()
+def sparse_rzxz_grid():
+    z = create_linearly_spaced_array_in_rzxz(5)
+    axangle = z.to_AxAngle()
+    return axangle
+
+@pytest.fixture()
+def along_z_axis():
+    axis = np.hstack((np.zeros((2000,2)),np.ones((2000,1))))
+    angle = np.linspace(-np.pi,np.pi,2000)
+    return AxAngle(np.hstack((axis,angle.reshape(-1,1))))
+
+@pytest.fixture()
+def along_x_axis():
+    axis = np.hstack((np.ones((2000,1)),np.zeros((2000,2))))
+    angle = np.linspace(-np.pi,np.pi,2000)
+    return AxAngle(np.hstack((axis,angle.reshape(-1,1))))
+
+""" Broad tests that check the code runs """
+
 def test_select_fundemental_zone():
     """ Makes sure all the ints from 1 to 230 give answers """
+    # Not done with parametrize to avoid clogging the output log (it's 230 tests if you do it that way)
     for _space_group in np.arange(1, 231):
         fz_string = get_proper_point_group_string(_space_group)
         assert fz_string in ['1', '2', '222', '3', '32', '6', '622', '4', '422', '432', '23']
 
+@pytest.mark.parametrize("fz_string", ['1', '2', '222', '3', '32', '6', '622', '4', '422', '432', '23'])
+def test_non_zero_returns(sparse_rzxz_grid,fz_string):
+    reduced_data = reduce_to_fundemental_zone(sparse_rzxz_grid,fz_string)
+    assert reduced_data.data.shape[0] > 0
+
+""" Cyclic case """
+
+@pytest.mark.parametrize("fz_string",['1','2','3','4','6'])
+def test_orthogonal_linear_case_for_cyclic_group(along_x_axis,fz_string):
+    """ Rotations about x feel no effect of the cyclic group """
+    reduced = reduce_to_fundemental_zone(along_x_axis,fz_string)
+    assert reduced.data.shape[0] == along_x_axis.data.shape[0]
+
+@pytest.mark.parametrize("order",[1,2,3,4,6])
+def test_cyclic(order):
+    """ Uniform spacing in RF """
+    axis = np.hstack((np.zeros((2000,2)),np.ones((2000,1))))
+    rf = np.tan(np.linspace(0,np.pi,2000))
+    z = np.hstack((axis,rf.reshape(-1,1)))
+    reduced = cyclic_group(z,order)
+    assert np.allclose(np.sum(reduced),2000/order,atol=3)
+
+@pytest.mark.skip(reason="Until the test above passes this is meaningless")
+def test_linear_case_for_cyclic_group(along_z_axis):
+    one = reduce_to_fundemental_zone(along_z_axis,'1')
+    two = reduce_to_fundemental_zone(along_z_axis,'2')
+    four = reduce_to_fundemental_zone(along_z_axis,'4')
+    six = reduce_to_fundemental_zone(along_z_axis,'6')
+    #assert six.data.shape[0]/four.data.shape[0] > 1.4
+    #assert six.data.shape[0]/four.data.shape[0] < 1.6
+    assert six.data.shape[0]/two.data.shape[0]  > 2.9
+    assert six.data.shape[0]/two.data.shape[0]  < 3.1
+    assert six.data.shape[0]/one.data.shape[0]  > 5.9
+    assert six.data.shape[0]/one.data.shape[0]  < 6.1
+    assert four.data.shape[0]/two.data.shape[0] > 2.9
+    assert four.data.shape[0]/two.data.shape[0] < 3.1
+
+
+
+#@pytest.mark.skip(reason="Slow and not ready yet")
+def test_cyclic_groups(fairly_dense_rzxz_grid):
+    one = reduce_to_fundemental_zone(fairly_dense_rzxz_grid,'1')
+    two = reduce_to_fundemental_zone(fairly_dense_rzxz_grid,'2')
+    four = reduce_to_fundemental_zone(fairly_dense_rzxz_grid,'4')
+    six = reduce_to_fundemental_zone(fairly_dense_rzxz_grid,'6')
+    assert six.data.shape[0]/four.data.shape[0] > 1.4
+    assert six.data.shape[0]/four.data.shape[0] < 1.6
+    assert six.data.shape[0]/two.data.shape[0]  > 2.9
+    assert six.data.shape[0]/two.data.shape[0]  < 3.1
+    assert six.data.shape[0]/one.data.shape[0]  > 5.9
+    assert six.data.shape[0]/one.data.shape[0]  < 6.1
+    assert four.data.shape[0]/two.data.shape[0] > 2.9
+    assert four.data.shape[0]/two.data.shape[0] < 3.1
+
+""" Internal edge cases """
 @pytest.mark.xfail(strict=True)
 def test_edge_case_numpy_bounding_plane():
     z = np.asarray([1,1,1,np.inf])

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The diffsims developers
+#
+# This file is part of diffsims.
+#
+# diffsims is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# diffsims is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+
+from diffsims.utils.fundemental_zone_utils import get_proper_point_group_string, reduce_to_fundemental_zone, numpy_bounding_plane
+
+""" These tests check the fundemental_zone section of the code """
+
+def test_select_fundemental_zone():
+    """ Makes sure all the ints from 1 to 230 give answers """
+    for _space_group in np.arange(1, 231):
+        fz_string = get_proper_point_group_string(_space_group)
+        assert fz_string in ['1', '2', '222', '3', '32', '6', '622', '4', '422', '432', '23']
+
+@pytest.mark.xfail(strict=True)
+def test_edge_case_numpy_bounding_plane():
+    z = np.asarray([1,1,1,np.inf])
+    numpy_bounding_plane(data=z,vector=[1,1,1],distance=1)

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -130,3 +130,21 @@ def test_dihedral_groups(sparse_rzxz_grid,point_group_str):
     assert r.data.shape[0] > 0
     assert r.data.shape[0] > (start_size * volume * 0.9)
     assert r.data.shape[0] < (start_size * volume * 1.1)
+
+""" Cubic cases """
+
+def test_tetragonal_group(sparse_rzxz_grid):
+    volume = 1 / (12) # From "On three dimensional misorientation spaces"
+    start_size = sparse_rzxz_grid.data.shape[0]
+    r = reduce_to_fundemental_zone(sparse_rzxz_grid,'23')
+    assert r.data.shape[0] > 0
+    assert r.data.shape[0] > (start_size * volume * 0.9)
+    assert r.data.shape[0] < (start_size * volume * 1.1)
+
+def test_octahedral_group(sparse_rzxz_grid):
+    volume = 1 / (24) # From "On three dimensional misorientation spaces"
+    start_size = sparse_rzxz_grid.data.shape[0]
+    r = reduce_to_fundemental_zone(sparse_rzxz_grid,'432')
+    assert r.data.shape[0] > 0
+    assert r.data.shape[0] > (start_size * volume * 0.9)
+    assert r.data.shape[0] < (start_size * volume * 1.1)

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -140,14 +140,16 @@ def test_dihedral_groups(sparse_rzxz_grid,point_group_str):
 
 """ Cubic cases """
 
+@pytest.mark.skip(reason="Not figure out what the volume term should be")
 def test_tetragonal_group(sparse_rzxz_grid):
-    volume = 1 / (12) # From "On three dimensional misorientation spaces"
+    volume = 1 / (8) # CHECK!
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,'23')
     assert_volume_changes_obeyed(r,start_size,volume)
 
+@pytest.mark.skip(reason="Not figured out what the volume should be")
 def test_octahedral_group(sparse_rzxz_grid):
-    volume = 1 / (24) # From "On three dimensional misorientation spaces"
+    volume = 1 / (14) # CHECK!
     start_size = sparse_rzxz_grid.data.shape[0]
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,'432')
     assert_volume_changes_obeyed(r,start_size,volume)

--- a/diffsims/tests/test_utils/test_fundamental_zone_utils.py
+++ b/diffsims/tests/test_utils/test_fundamental_zone_utils.py
@@ -138,18 +138,22 @@ def test_dihedral_groups(sparse_rzxz_grid,point_group_str):
     r = reduce_to_fundemental_zone(sparse_rzxz_grid,point_group_str)
     assert_volume_changes_obeyed(r,start_size,volume)
 
-""" Cubic cases """
+""" Cubic case """
 
-@pytest.mark.skip(reason="Not figure out what the volume term should be")
-def test_tetragonal_group(sparse_rzxz_grid):
-    volume = 1 / (8) # CHECK!
-    start_size = sparse_rzxz_grid.data.shape[0]
-    r = reduce_to_fundemental_zone(sparse_rzxz_grid,'23')
-    assert_volume_changes_obeyed(r,start_size,volume)
+@pytest.fixture()
+def dense_rzxz_grid():
+    z = create_linearly_spaced_array_in_rzxz(1)
+    axangle = z.to_AxAngle()
+    return axangle
 
-@pytest.mark.skip(reason="Not figured out what the volume should be")
-def test_octahedral_group(sparse_rzxz_grid):
-    volume = 1 / (14) # CHECK!
-    start_size = sparse_rzxz_grid.data.shape[0]
-    r = reduce_to_fundemental_zone(sparse_rzxz_grid,'432')
-    assert_volume_changes_obeyed(r,start_size,volume)
+def test_tetragonal_group(dense_rzxz_grid):
+    full_volume  = (4/3) * np.pi * (180)**3
+    outer_volume = (4/3) * np.pi * (90)**3
+    #https://en.wikipedia.org/wiki/Octahedron
+    r_inner = 90 * np.sqrt(1/3)
+    inner_volume = (4/3) * np.pi * (r_inner)**3
+    start_size = dense_rzxz_grid.data.shape[0]
+    r = reduce_to_fundemental_zone(dense_rzxz_grid,'23')
+    observed_ratio = r.data.shape[0] / start_size
+    assert observed_ratio < outer_volume/full_volume
+    assert observed_ratio > inner_volume/full_volume

--- a/diffsims/tests/test_utils/test_gridding_utils.py
+++ b/diffsims/tests/test_utils/test_gridding_utils.py
@@ -20,7 +20,6 @@ import pytest
 import numpy as np
 
 from diffsims.utils.rotation_conversion_utils import AxAngle, Euler
-from diffsims.utils.fundemental_zone_utils import get_proper_point_group_string, reduce_to_fundemental_zone, numpy_bounding_plane
 from diffsims.utils.gridding_utils import create_linearly_spaced_array_in_rzxz, vectorised_qmult, \
                                           _create_advanced_linearly_spaced_array_in_rzxz, get_beam_directions
 
@@ -50,20 +49,6 @@ def test_linearly_spaced_array_in_rzxz():
     assert isinstance(grid, Euler)
     assert grid.axis_convention == 'rzxz'
     assert grid.data.shape == (442368, 3)
-
-
-""" These tests check the fundemental_zone section of the code """
-
-def test_select_fundemental_zone():
-    """ Makes sure all the ints from 1 to 230 give answers """
-    for _space_group in np.arange(1, 231):
-        fz_string = get_proper_point_group_string(_space_group)
-        assert fz_string in ['1', '2', '222', '3', '32', '6', '622', '4', '422', '432', '23']
-
-@pytest.mark.xfail(strict=True)
-def test_edge_case_numpy_bounding_plane():
-    z = np.asarray([1,1,1,np.inf])
-    numpy_bounding_plane(data=z,vector=[1,1,1],distance=1)
 
 """ This tests get_beam_directions """
 @pytest.mark.parametrize("crystal_system,expected_corners",

--- a/diffsims/utils/fundemental_zone_utils.py
+++ b/diffsims/utils/fundemental_zone_utils.py
@@ -133,7 +133,7 @@ def cyclic_group(data, order):
     # As pi rotations are present in the input and output we avoid a call to numpy_bounding_plane
     z_distance = np.multiply(data[:,2], data[:,3]) # gets the z component of the distance, can be nan
     z_distance = np.abs(np.nan_to_num(z_distance))  # case pi rotation, 0 z component of vector
-    mask = z_distance < np.tan(np.pi / (2*order))
+    mask =  z_distance < np.tan(np.pi / (2*order))
     return mask
 
 def dihedral_group(data, order):

--- a/diffsims/utils/fundemental_zone_utils.py
+++ b/diffsims/utils/fundemental_zone_utils.py
@@ -133,7 +133,7 @@ def cyclic_group(data, order):
     # As pi rotations are present in the input and output we avoid a call to numpy_bounding_plane
     z_distance = np.multiply(data[:,2], data[:,3]) # gets the z component of the distance, can be nan
     z_distance = np.abs(np.nan_to_num(z_distance))  # case pi rotation, 0 z component of vector
-    mask = z_distance < np.tan(np.pi / order)
+    mask = z_distance < np.tan(np.pi / (2*order))
     return mask
 
 def dihedral_group(data, order):

--- a/diffsims/utils/fundemental_zone_utils.py
+++ b/diffsims/utils/fundemental_zone_utils.py
@@ -104,7 +104,7 @@ def numpy_bounding_plane(data, vector, distance):
         raise ValueError("Your data contains rotations of pi")
 
     n_vector = np.divide(vector,np.linalg.norm(vector))
-    inner_region = np.abs(np.dot(data[:,:3],n_vector)) < distance
+    inner_region = (np.abs(np.dot(data[:,:3],n_vector))*data[:,3]) < distance
 
     return inner_region
 


### PR DESCRIPTION
---
name: Bugfixs for fundamental zone functionality
about: #64 illustrates that some thing were broken, this PR brings in better tests and some fixes

- [ ] ready for review and merge?
---

**Release Notes**
> n/a merge into #47 

**What does this PR do? Please describe and/or link to an open issue.**
1) Adds a load of new tests that check volumes for fundamental zones
2) Fixes various bugs that would have meant these tests failed

**Are there any known issues? Do you need help?**
Finding the volumes of asym domains for Cyclic/Dihedral cases was fine (it's in Moraweic) but doing so for the cubic cases is harder. You can't use RF as it's divergent and the axis angle parameterisations have curved surfaces. It's hard to think of an alternative test that would be as convincing.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [ ] Renames of all "fundemental" to "fundamental" (MOVED TO SEPARATE PR)
- [x] cubic test cases


