### PR TITLE
Missing __init__.py in folder atomic_diffraction_generator_support

### DIFF
--- a/diffsims/utils/atomic_diffraction_generator_support/__init__.py
+++ b/diffsims/utils/atomic_diffraction_generator_support/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2020 The diffsims developers
+#
+# This file is part of diffsims.
+#
+# diffsims is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# diffsims is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with diffsims.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
---
name: Missing __init__.py
about: A bugfix

---

An empty file with name __init__.py. Added licence. 

Related to issue #70 by Endre. 


