### PR TITLE
Function: Get StructureLibrary size (total # of orientations)

### DIFF
--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -56,6 +56,35 @@ class StructureLibrary():
         for ident, struct, ori in zip(identifiers, structures, orientations):
             self.struct_lib[ident] = (struct, ori)
 
+    def get_library_size(cls, to_print = False):
+        """
+        Returns the number of structures in the current StructureLibrary
+        object. Will also print the number of entries for each structure in
+        the library if the parameter to_print is set to True. Works with both
+        cls.orientations on the form [1,2] and [[1,2], [2,3]](rotation lists).
+
+        Parameters
+        ----------
+        to_print : bool
+            Default is 'False'
+            Returns
+            -------
+            size_library : int
+                Total number of entries in the current StructureLibrary object.
+        """
+        size_library = 0
+        for i in range (len(cls.orientations)):
+            if type(cls.orientations[i]) != list:
+                size_library += 1
+            else:
+                size_library += len(cls.orientations[i])
+            if to_print == True and type(cls.orientations[i]) == list:
+                    print(cls.identifiers[i], "has", \
+                    len(cls.orientations[i]), "number of entries.")
+                    if to_print == True:
+                        print("\nIn total:", size_library, "number of entries")
+                    return size_library
+
     @classmethod
     def from_orientation_lists(cls, identifiers, structures, orientations):
         """

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -105,7 +105,7 @@ class StructureLibrary():
             orientations.append(get_grid_streographic(system, resolution, equal))
         return cls(identifiers, structures, orientations)
     
-     def get_library_size(self, to_print = False):
+    def get_library_size(self, to_print = False):
         """
         Returns the the total number of orientations in the
         current StructureLibrary object. Will also print the number of orientations

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -56,12 +56,12 @@ class StructureLibrary():
         for ident, struct, ori in zip(identifiers, structures, orientations):
             self.struct_lib[ident] = (struct, ori)
 
-    def get_library_size(cls, to_print = False):
+    def get_library_size(self, to_print = False):
         """
         Returns the the total number of orientations in the
         current StructureLibrary object. Will also print the number of orientations
         for each identifier in the library if the parameter to_print is set to
-        True. Works with both cls.orientations on the form [1,2]
+        True. Works with both self.orientations on the form [1,2]
         and [[1,2], [2,3]](rotation lists).
 
         Parameters
@@ -74,14 +74,14 @@ class StructureLibrary():
             Total number of entries in the current StructureLibrary object.
         """
         size_library = 0
-        for i in range (len(cls.orientations)):
-            if type(cls.orientations[i]) != list:
+        for i in range (len(self.orientations)):
+            if type(self.orientations[i]) != list:
                 size_library += 1
             else:
-                size_library += len(cls.orientations[i])
-            if to_print == True and type(cls.orientations[i]) == list:
-                print(cls.identifiers[i], "has", \
-                len(cls.orientations[i]), "number of entries.")
+                size_library += len(self.orientations[i])
+            if to_print == True and type(self.orientations[i]) == list:
+                print(self.identifiers[i], "has", \
+                len(self.orientations[i]), "number of entries.")
         if to_print == True:
             print("\nIn total:", size_library, "number of entries")
         return size_library

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -81,8 +81,8 @@ class StructureLibrary():
             if to_print == True and type(cls.orientations[i]) == list:
                 print(cls.identifiers[i], "has", \
                 len(cls.orientations[i]), "number of entries.")
-                    if to_print == True:
-                        print("\nIn total:", size_library, "number of entries")
+                if to_print == True:
+                    print("\nIn total:", size_library, "number of entries")
         return size_library
 
     @classmethod

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -56,36 +56,7 @@ class StructureLibrary():
         for ident, struct, ori in zip(identifiers, structures, orientations):
             self.struct_lib[ident] = (struct, ori)
 
-    def get_library_size(self, to_print = False):
-        """
-        Returns the the total number of orientations in the
-        current StructureLibrary object. Will also print the number of orientations
-        for each identifier in the library if the parameter to_print is set to
-        True. Works with both self.orientations on the form [1,2]
-        and [[1,2], [2,3]](rotation lists).
-
-        Parameters
-        ----------
-        to_print : bool
-            Default is 'False'
-            Returns
-            -------
-        size_library : int
-            Total number of entries in the current StructureLibrary object.
-        """
-        size_library = 0
-        for i in range (len(self.orientations)):
-            if len(self.orientations[i]) == 1:
-                size_library += 1
-            else:
-                size_library += len(self.orientations[i])
-            if to_print == True:
-                print(self.identifiers[i], "has", \
-                len(self.orientations[i]), "number of entries.")
-        if to_print == True:
-            print("\nIn total:", size_library, "number of entries")
-        return size_library
-
+   
     @classmethod
     def from_orientation_lists(cls, identifiers, structures, orientations):
         """
@@ -133,3 +104,31 @@ class StructureLibrary():
         for system in systems:
             orientations.append(get_grid_streographic(system, resolution, equal))
         return cls(identifiers, structures, orientations)
+    
+     def get_library_size(self, to_print = False):
+        """
+        Returns the the total number of orientations in the
+        current StructureLibrary object. Will also print the number of orientations
+        for each identifier in the library if the to_print==True
+        
+        Parameters
+        ----------
+        to_print : bool
+            Default is 'False'
+        Returns
+        -------
+        size_library : int
+            Total number of entries in the current StructureLibrary object.
+        """
+        size_library = 0
+        for i in range (len(self.orientations)):
+            if len(self.orientations[i]) == 1:
+                size_library += 1
+            else:
+                size_library += len(self.orientations[i])
+            if to_print == True:
+                print(self.identifiers[i], "has", \
+                len(self.orientations[i]), "number of entries.")
+        if to_print == True:
+            print("\nIn total:", size_library, "number of entries")
+        return size_library

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -70,8 +70,8 @@ class StructureLibrary():
             Default is 'False'
             Returns
             -------
-            size_library : int
-                Total number of entries in the current StructureLibrary object.
+        size_library : int
+            Total number of entries in the current StructureLibrary object.
         """
         size_library = 0
         for i in range (len(cls.orientations)):

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -82,8 +82,8 @@ class StructureLibrary():
             if to_print == True and type(cls.orientations[i]) == list:
                 print(cls.identifiers[i], "has", \
                 len(cls.orientations[i]), "number of entries.")
-                if to_print == True:
-                    print("\nIn total:", size_library, "number of entries")
+        if to_print == True:
+            print("\nIn total:", size_library, "number of entries")
         return size_library
 
     @classmethod

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -79,11 +79,11 @@ class StructureLibrary():
             else:
                 size_library += len(cls.orientations[i])
             if to_print == True and type(cls.orientations[i]) == list:
-                    print(cls.identifiers[i], "has", \
-                    len(cls.orientations[i]), "number of entries.")
+                print(cls.identifiers[i], "has", \
+                len(cls.orientations[i]), "number of entries.")
                     if to_print == True:
                         print("\nIn total:", size_library, "number of entries")
-                    return size_library
+        return size_library
 
     @classmethod
     def from_orientation_lists(cls, identifiers, structures, orientations):

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -75,11 +75,11 @@ class StructureLibrary():
         """
         size_library = 0
         for i in range (len(self.orientations)):
-            if type(self.orientations[i]) != tuple:
+            if len(self.orientations[i]) == 1:
                 size_library += 1
             else:
                 size_library += len(self.orientations[i])
-            if to_print == True and type(self.orientations[i]) == tuple:
+            if to_print == True:
                 print(self.identifiers[i], "has", \
                 len(self.orientations[i]), "number of entries.")
         if to_print == True:

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -75,11 +75,11 @@ class StructureLibrary():
         """
         size_library = 0
         for i in range (len(self.orientations)):
-            if type(self.orientations[i]) != list:
+            if type(self.orientations[i]) != tuple:
                 size_library += 1
             else:
                 size_library += len(self.orientations[i])
-            if to_print == True and type(self.orientations[i]) == list:
+            if to_print == True and type(self.orientations[i]) == tuple:
                 print(self.identifiers[i], "has", \
                 len(self.orientations[i]), "number of entries.")
         if to_print == True:

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -58,10 +58,11 @@ class StructureLibrary():
 
     def get_library_size(cls, to_print = False):
         """
-        Returns the number of structures in the current StructureLibrary
-        object. Will also print the number of entries for each structure in
-        the library if the parameter to_print is set to True. Works with both
-        cls.orientations on the form [1,2] and [[1,2], [2,3]](rotation lists).
+        Returns the the total number of orientations in the
+        current StructureLibrary object. Will also print the number of orientations
+        for each identifier in the library if the parameter to_print is set to
+        True. Works with both cls.orientations on the form [1,2]
+        and [[1,2], [2,3]](rotation lists).
 
         Parameters
         ----------

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -24,7 +24,7 @@ from diffsims.libraries.structure_library import StructureLibrary
 def test_get_library_size():
     identifiers = ['a', 'b']
     structures = [1, 2]
-    rotation_list = [[3,1], [4,5]]
+    rotation_list = [(3,1), (4,5)]
     orientations = [1, 2]
     first_library = StructureLibrary(identifiers, structures, rotation_list)
     second_library = StructureLibrary(identifiers, structures, orientations)

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -24,7 +24,7 @@ from diffsims.libraries.structure_library import StructureLibrary
 def test_get_library_size():
     identifiers = ['a', 'b']
     structures = [1, 2]
-    rotation_list = [(3,1), (4,5)]
+    rotation_list = [(3, 1), (4, 5)]
     orientations = [1, 2]
     first_library = StructureLibrary(identifiers, structures, rotation_list)
     second_library = StructureLibrary(identifiers, structures, orientations)

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -21,6 +21,17 @@ import numpy as np
 
 from diffsims.libraries.structure_library import StructureLibrary
 
+def test_get_library_size():
+    identifiers = ['a', 'b']
+    structures = [1, 2]
+    rotation_list = [[3,1], [4,5]]
+    orientations = [1, 2]
+    first_library = StructureLibrary(identifiers, structures, rotation_list)
+    second_library = StructureLibrary(identifiers, structures, orientations)
+    # Test for rotation list
+    assert first_library.get_library_size() == 4
+    # Test for single orientation
+    assert second_library.get_library_size() == 2
 
 def test_from_orientations_method():
     identifiers = ['a', 'b']

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -24,9 +24,9 @@ from diffsims.libraries.structure_library import StructureLibrary
 def test_get_library_size():
     identifiers = ['a', 'b']
     structures = [1, 2]
-    rotation_list = [[(0, 0, 0), (0.0, 90.0, -180.0)], [(0, 0, 0)]]
-    first_library = StructureLibrary(identifiers, structures, rotation_list)
-    assert first_library.get_library_size(to_print = True) == 3
+    orientations = [[(0, 0, 0), (0.0, 90.0, -180.0)], [(0, 0, 0)]]
+    library = StructureLibrary(identifiers, structures, orientations)
+    assert library.get_library_size(to_print = True) == 3
 
 def test_from_orientations_method():
     identifiers = ['a', 'b']

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -29,9 +29,9 @@ def test_get_library_size():
     first_library = StructureLibrary(identifiers, structures, rotation_list)
     second_library = StructureLibrary(identifiers, structures, orientations)
     # Test for rotation list
-    assert first_library.get_library_size() == 4
+    assert first_library.get_library_size(to_print = True) == 4
     # Test for single orientation
-    assert second_library.get_library_size() == 2
+    assert second_library.get_library_size(to_print = True) == 2
 
 def test_from_orientations_method():
     identifiers = ['a', 'b']

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -24,14 +24,9 @@ from diffsims.libraries.structure_library import StructureLibrary
 def test_get_library_size():
     identifiers = ['a', 'b']
     structures = [1, 2]
-    rotation_list = [[(0, 0, 0), (0.0, 90.0, -180.0)], [(0, 0, 0), (0, 90.0, -180.0)]]
-    orientations = [[(0, 0, 0)], [(0, 90.0, -180.0)]]
+    rotation_list = [[(0, 0, 0), (0.0, 90.0, -180.0)], [(0, 0, 0)]]
     first_library = StructureLibrary(identifiers, structures, rotation_list)
-    second_library = StructureLibrary(identifiers, structures, orientations)
-    # Test for rotation list
-    assert first_library.get_library_size(to_print = True) == 4
-    # Test for single orientation
-    assert second_library.get_library_size(to_print = True) == 2
+    assert first_library.get_library_size(to_print = True) == 3
 
 def test_from_orientations_method():
     identifiers = ['a', 'b']

--- a/diffsims/tests/test_library/test_structure_library.py
+++ b/diffsims/tests/test_library/test_structure_library.py
@@ -24,8 +24,8 @@ from diffsims.libraries.structure_library import StructureLibrary
 def test_get_library_size():
     identifiers = ['a', 'b']
     structures = [1, 2]
-    rotation_list = [(3, 1), (4, 5)]
-    orientations = [1, 2]
+    rotation_list = [[(0, 0, 0), (0.0, 90.0, -180.0)], [(0, 0, 0), (0, 90.0, -180.0)]]
+    orientations = [[(0, 0, 0)], [(0, 90.0, -180.0)]]
     first_library = StructureLibrary(identifiers, structures, rotation_list)
     second_library = StructureLibrary(identifiers, structures, orientations)
     # Test for rotation list


### PR DESCRIPTION
---
name: Get StructureLibrary size
about: Adds a function to the class StructureLibrary that returns the total number of orientations
---

**What does this PR do? Please describe and/or link to an open issue.**
Adds a function to the class StructureLibrary that returns the total number of orientations and the possibility to print each identifier with its corresponding number of orientations(setting to_print = True). This function may be used to monitor the the library size, when for example doing Template Matching.

Example output when argument to_print is True.
```
Al has 720 number of entries.
Betap has 360 number of entries.
BetaDP has 360 number of entries.
There are in total 1440 number of entries
```
The function returns:
`1440`