### PR TITLE
[fix] Gimbal locks in _create_rzxz grid

### DIFF
--- a/diffsims/tests/test_generators/test_rotation_list_generator.py
+++ b/diffsims/tests/test_generators/test_rotation_list_generator.py
@@ -41,8 +41,8 @@ def test_get_grid_around_beam_direction():
 
 @pytest.mark.parametrize("space_group_number", [1, 3, 30, 190, 215, 229])
 def test_get_fundamental_zone_grid(space_group_number):
-    grid_narrow = get_fundamental_zone_grid(space_group_number, resolution=6)
-    grid_wide = get_fundamental_zone_grid(space_group_number, resolution=12)
+    grid_narrow = get_fundamental_zone_grid(space_group_number, resolution=4)
+    grid_wide = get_fundamental_zone_grid(space_group_number, resolution=8)
     assert (len(grid_narrow) / len(grid_wide)) > (2**3) - 1  # lower bounds
     assert (len(grid_narrow) / len(grid_wide)) < (2**3) + 1  # upper bounds
 

--- a/diffsims/tests/test_utils/test_gridding_utils.py
+++ b/diffsims/tests/test_utils/test_gridding_utils.py
@@ -47,12 +47,13 @@ def test_linearly_spaced_array_in_rzxz():
         Two sides of length = 96
         One side of length  = 48
         And thus a total of 96 * 96 * 48 = 442368 points
+        Which is an upper bound after we remove gimbal lock rotations
     """
     grid = create_linearly_spaced_array_in_rzxz(resolution=3.75)
     assert isinstance(grid, Euler)
     assert grid.axis_convention == 'rzxz'
-    assert grid.data.shape == (442368, 3)
-
+    assert grid.data.shape[0] < 442368
+    assert grid.data.shape[1] == 3
 
 """ This tests get_beam_directions """
 

--- a/diffsims/utils/gridding_utils.py
+++ b/diffsims/utils/gridding_utils.py
@@ -153,9 +153,19 @@ def _create_advanced_linearly_spaced_array_in_rzxz(resolution, max_alpha, max_be
     steps_gamma = int(np.ceil((max_gamma - 0) / resolution))
 
     alpha = np.linspace(0, max_alpha, num=steps_alpha, endpoint=False)
-    beta = np.linspace(0, max_beta, num=steps_beta, endpoint=False)
+    beta = np.linspace(resolution, max_beta, num=steps_beta, endpoint=False) #this avoid gimbal lock roations
     gamma = np.linspace(0, max_gamma, num=steps_gamma, endpoint=False)
     z = np.asarray(list(product(alpha, beta, gamma)))
+
+    # We now add the rotations for which the middle angle is zero, we use the form (0,0,gamma)
+    max_gimbal_rotation = max_alpha + max_gamma
+    if max_gimbal_rotation > 360:
+        max_gimbal_rotation = 360
+
+    gamma_final = np.linspace(0,max_gimbal_rotation,int(np.floor(max_gimbal_rotation/resolution)+1),endpoint=True)
+    z_gimbals = np.hstack((np.zeros((gamma_final.shape[0],2)),gamma_final.reshape(gamma_final.shape[0],-1)))
+
+    z = np.vstack((z,z_gimbals))
     return Euler(z, axis_convention='rzxz')
 
 

--- a/diffsims/utils/gridding_utils.py
+++ b/diffsims/utils/gridding_utils.py
@@ -149,7 +149,7 @@ def _create_advanced_linearly_spaced_array_in_rzxz(resolution, max_alpha, max_be
     # We use np.linspace rather than np.arange to get list of evenly spaced Euler
     # angles due to better end point handling. Therefore convert "step_size" to a "num"
     steps_alpha = int(np.ceil((max_alpha - 0) / resolution))
-    steps_beta = int(np.ceil((max_beta - 0) / resolution))
+    steps_beta = int(np.ceil((max_beta - resolution) / resolution))
     steps_gamma = int(np.ceil((max_gamma - 0) / resolution))
 
     alpha = np.linspace(0, max_alpha, num=steps_alpha, endpoint=False)
@@ -162,7 +162,7 @@ def _create_advanced_linearly_spaced_array_in_rzxz(resolution, max_alpha, max_be
     if max_gimbal_rotation > 360:
         max_gimbal_rotation = 360
 
-    gamma_final = np.linspace(0,max_gimbal_rotation,int(np.floor(max_gimbal_rotation/resolution)+1),endpoint=True)
+    gamma_final = np.linspace(0,max_gimbal_rotation,num=int(np.ceil(max_gimbal_rotation/resolution)),endpoint=False)
     z_gimbals = np.hstack((np.zeros((gamma_final.shape[0],2)),gamma_final.reshape(gamma_final.shape[0],-1)))
 
     z = np.vstack((z,z_gimbals))


### PR DESCRIPTION
---
name: [fix] Gimbal locks in `_create_rzxz grid`
about: Drops gimbal lock rotations from grid creation

---

**Release Notes**
>bugfix 
Summary: Drops gimbal lock rotations from grid creation

**What does this PR do? Please describe and/or link to an open issue.**
Previously our deepest back-end code would generate our array of eulers using product, with 0 included in the beta slot this meant you would get:
```
1 0 1
2 0 0 
etc
```

Which are all the same rotation, this PR fixes this. The product stage doesn't include beta=0 but those rotation are added in a subsequent step as `(0,0,gammas)`

