### PR TITLE
Add numba and psutil to pip setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,9 @@ setup(
         'matplotlib>=3.1.1',
         'tqdm>=0.4.9',
         'transforms3d',
-        'diffpy.structure>=3.0.0'  # First Python 3 support
+        'diffpy.structure>=3.0.0',  # First Python 3 support
+        'numba',
+        'psutil',
     ],
     python_requires='>=3.6',
     package_data={


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

**Release Notes**
> developer change
Summary: Add numba and psutil to pip setup file

**What does this PR do? Please describe and/or link to an open issue.**
When [Travis builds KikuchiPy with pip](https://travis-ci.org/kikuchipy/kikuchipy/jobs/656420542?utm_medium=notification&utm_source=github_status) our tests fail immediately because:
```bash
ImportError while loading conftest '/home/travis/build/kikuchipy/kikuchipy/kikuchipy/conftest.py'.
kikuchipy/__init__.py:20: in <module>
    from kikuchipy import signals
kikuchipy/signals/__init__.py:19: in <module>
    from kikuchipy.signals.ebsd import EBSD, LazyEBSD
kikuchipy/signals/ebsd.py:36: in <module>
    from pyxem.signals.diffraction2d import Diffraction2D
../../../testenv/lib/python3.7/site-packages/pyxem/__init__.py:33: in <module>
    from diffsims.generators.diffraction_generator import DiffractionGenerator
../../../testenv/lib/python3.7/site-packages/diffsims/__init__.py:33: in <module>
    from .utils.atomic_diffraction_generator_support.discretise_utils import get_discretisation
../../../testenv/lib/python3.7/site-packages/diffsims/utils/atomic_diffraction_generator_support/discretise_utils.py:26: in <module>
    from psutil import virtual_memory
E   ModuleNotFoundError: No module named 'psutil'
The command "python -m pytest --cov=kikuchipy --pyargs kikuchipy" exited with 4.
```

Running these steps locally also raised errors that `numba` and `psutil` weren't installed:
```bash
git clone https://github.com/pyxem/diffsims.git
cd diffsims
pip install -e .
pip install pytest
pytest --pyargs diffsims
ImportError while loading conftest '/home/hakon/kode/diffsims/diffsims/tests/conftest.py'.
diffsims/__init__.py:25: in <module>
    from .generators.diffraction_generator import DiffractionGenerator, AtomicDiffractionGenerator
diffsims/generators/diffraction_generator.py:34: in <module>
    from diffsims.utils.atomic_diffraction_generator_support.fourier_transform import from_recip
diffsims/utils/atomic_diffraction_generator_support/fourier_transform.py:29: in <module>
    import numba
E   ModuleNotFoundError: No module named 'numba'
```

Tests run fine after `numba` and `psutil` are installed. I therefore added these to `setup.py`.