### PR TITLE
Moved utils from pyxem/pixstem into diffsims/utils/sim_utils.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ src/
 .vscode/
 /.project
 /.pydevproject
+
+#Ds store stuff
+.DS_store

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -270,9 +270,7 @@ class DiffractionGenerator(object):
                 # Use Miller-Bravais indices for hexagonal lattices.
                 hkl = (hkl[0], hkl[1], -hkl[0] - hkl[1], hkl[2])
 
-
-            ##swapped tuple(hkl) and g_hkl such that planes from same family dont overwrite
-            peaks[tuple(hkl)] = [i_hkl, g_hkl, d_hkl]
+            peaks[g_hkl] = [i_hkl, [tuple(hkl)], d_hkl]
 
         # Scale intensities so that the max intensity is 100.
         max_intensity = max([v[0] for v in peaks.values()])
@@ -282,11 +280,9 @@ class DiffractionGenerator(object):
         d_hkls = []
         for k in sorted(peaks.keys()):
             v = peaks[k]
-            fam = get_unique_families([k])
-            ##swapped v[1] for [k] ie put in tuple(hkl)
+            fam = get_unique_families(v[1])
             if v[0] / max_intensity * 100 > minimum_intensity:
-                x.append(v[1])
-                ##swapped k for v[1] ie add g_hkl to x list
+                x.append(k)
                 y.append(v[0])
                 hkls.append(fam)
                 d_hkls.append(v[2])

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -270,7 +270,9 @@ class DiffractionGenerator(object):
                 # Use Miller-Bravais indices for hexagonal lattices.
                 hkl = (hkl[0], hkl[1], -hkl[0] - hkl[1], hkl[2])
 
-            peaks[g_hkl] = [i_hkl, [tuple(hkl)], d_hkl]
+
+            ##swapped tuple(hkl) and g_hkl such that planes from same family dont overwrite
+            peaks[tuple(hkl)] = [i_hkl, g_hkl, d_hkl]
 
         # Scale intensities so that the max intensity is 100.
         max_intensity = max([v[0] for v in peaks.values()])
@@ -280,9 +282,11 @@ class DiffractionGenerator(object):
         d_hkls = []
         for k in sorted(peaks.keys()):
             v = peaks[k]
-            fam = get_unique_families(v[1])
+            fam = get_unique_families([k])
+            ##swapped v[1] for [k] ie put in tuple(hkl)
             if v[0] / max_intensity * 100 > minimum_intensity:
-                x.append(k)
+                x.append(v[1])
+                ##swapped k for v[1] ie add g_hkl to x list
                 y.append(v[0])
                 hkls.append(fam)
                 d_hkls.append(v[2])

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -146,6 +146,7 @@ def test_uvtw_to_uvw(uvtw, uvw):
     val = uvtw_to_uvw(uvtw)
     np.testing.assert_almost_equal(val, uvw)
 
+
 class TestHolzCalibration:
     def test_get_holz_angle(self):
         wavelength = 2.51 / 1000
@@ -158,6 +159,7 @@ class TestHolzCalibration:
         angle = 95.37805 / 1000
         lattice_size = scattering_angle_to_lattice_parameter(wavelength, angle)
         assert approx(0.55225047) == lattice_size
+
 
 class TestBetaToBst:
     def test_zero(self):
@@ -217,6 +219,7 @@ class TestEtToBeta:
         assert data.shape == beta.shape
         assert (data != 0.0).all()
 
+
 class TeslaToAm:
     def test_zero(self):
         data = np.zeros((100, 100))
@@ -256,6 +259,7 @@ class TestAccelerationVoltageToRelativisticMass:
     def test_200kv(self):
         mr = acceleration_voltage_to_relativistic_mass(200000)
         assert approx(mr) == 1.268e-30
+
 
 @pytest.mark.parametrize(
     "av,wl", [(100000, 3.701e-12), (200000, 2.507e-12), (300000, 1.968e-12)]

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -220,7 +220,7 @@ class TestEtToBeta:
         assert (data != 0.0).all()
 
 
-class TeslaToAm:
+class TestTeslaToAm:
     def test_zero(self):
         data = np.zeros((100, 100))
         am = tesla_to_am(data)

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -33,16 +33,16 @@ from diffsims.utils.sim_utils import (
     simulate_kinematic_scattering,
     is_lattice_hexagonal,
     uvtw_to_uvw,
-    get_holz_angle
-    scattering_angle_to_lattice_parameter
-    bst_to_beta
-    beta_to_bst
-    tesla_to_am
-    acceleration_voltage_to_velocity
-    acceleration_voltage_to_relativistic_mass
-    et_to_beta
-    acceleration_voltage_to_wavelength
-    diffraction_scattering_angle
+    get_holz_angle,
+    scattering_angle_to_lattice_parameter,
+    bst_to_beta,
+    beta_to_bst,
+    tesla_to_am,
+    acceleration_voltage_to_velocity,
+    acceleration_voltage_to_relativistic_mass,
+    et_to_beta,
+    acceleration_voltage_to_wavelength,
+    diffraction_scattering_angle,
 )
 
 

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -217,6 +217,24 @@ class TestEtToBeta:
         assert data.shape == beta.shape
         assert (data != 0.0).all()
 
+class TeslaToAm:
+    def test_zero(self):
+        data = np.zeros((100, 100))
+        am = tesla_to_am(data)
+        assert data.shape == am.shape
+        assert (data == 0.00).all()
+
+    def test_ones(self):
+        data = np.ones((100, 100)) * 10
+        am = tesla_to_am(data)
+        assert data.shape == am.shape
+        assert (data != 0.0).all()
+
+    def test_known_value(self):
+        tesla = 1
+        am = tesla_to_am(tesla)
+        assert approx(tesla, rel=1e-4) == 795775
+
 
 class TestAccelerationVoltageToVelocity:
     def test_zero(self):

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -19,6 +19,11 @@
 import pytest
 import numpy as np
 import diffpy
+from pytest import approx
+import pyxem.utils.dpc_utils as dpct
+import scipy.constants as sc
+import pyxem.utils.diffraction_tools as dt
+
 
 from diffsims.utils.sim_utils import (
     get_electron_wavelength,
@@ -132,3 +137,154 @@ def test_kinematic_simulator_invalid_illumination():
 def test_uvtw_to_uvw(uvtw, uvw):
     val = uvtw_to_uvw(uvtw)
     np.testing.assert_almost_equal(val, uvw)
+
+class TestHolzCalibration:
+    def test_get_holz_angle(self):
+        wavelength = 2.51 / 1000
+        lattice_parameter = 0.3905 * 2 ** 0.5
+        angle = ra._get_holz_angle(wavelength, lattice_parameter)
+        assert approx(95.37805 / 1000) == angle
+
+    def test_scattering_angle_to_lattice_parameter(self):
+        wavelength = 2.51 / 1000
+        angle = 95.37805 / 1000
+        lattice_size = ra._scattering_angle_to_lattice_parameter(wavelength, angle)
+        assert approx(0.55225047) == lattice_size
+
+class TestBetaToBst:
+    def test_zero(self):
+        data = np.zeros((100, 100))
+        bst = dpct.beta_to_bst(data, 200000)
+        assert data.shape == bst.shape
+        assert (data == 0.0).all()
+
+    def test_ones(self):
+        data = np.ones((100, 100)) * 10
+        bst = dpct.beta_to_bst(data, 200000)
+        assert data.shape == bst.shape
+        assert (data != 0.0).all()
+
+    def test_beta_to_bst_to_beta(self):
+        beta = 2e-6
+        output = dpct.bst_to_beta(dpct.beta_to_bst(beta, 200000), 200000)
+        assert beta == output
+
+    def test_known_value(self):
+        # From https://dx.doi.org/10.1016/j.ultramic.2016.03.006
+        bst = 10e-9 * 1  # 10 nm, 1 Tesla
+        av = 200000  # 200 kV
+        beta = dpct.bst_to_beta(bst, av)
+        assert approx(beta, rel=1e-4) == 6.064e-6
+
+
+class TestBstToBeta:
+    def test_zero(self):
+        data = np.zeros((100, 100))
+        beta = dpct.bst_to_beta(data, 200000)
+        assert data.shape == beta.shape
+        assert (data == 0.0).all()
+
+    def test_ones(self):
+        data = np.ones((100, 100)) * 10
+        beta = dpct.bst_to_beta(data, 200000)
+        assert data.shape == beta.shape
+        assert (data != 0.0).all()
+
+    def test_bst_to_beta_to_bst(self):
+        bst = 10e-6
+        output = dpct.beta_to_bst(dpct.bst_to_beta(bst, 200000), 200000)
+        assert bst == output
+
+
+class TestEtToBeta:
+    def test_zero(self):
+        data = np.zeros((100, 100))
+        beta = dpct.et_to_beta(data, 200000)
+        assert data.shape == beta.shape
+        assert (data == 0.0).all()
+
+    def test_ones(self):
+        data = np.ones((100, 100)) * 10
+        beta = dpct.bst_to_beta(data, 200000)
+        assert data.shape == beta.shape
+        assert (data != 0.0).all()
+
+
+class TestAccelerationVoltageToVelocity:
+    def test_zero(self):
+        assert dpct.acceleration_voltage_to_velocity(0) == 0.0
+
+    @pytest.mark.parametrize(
+        "av,vel", [(100000, 1.6434e8), (200000, 2.0844e8), (300000, 2.3279e8)]
+    )  # V, m/s
+    def test_values(self, av, vel):
+        v = dpct.acceleration_voltage_to_velocity(av)
+        assert approx(v, rel=0.001) == vel
+
+
+class TestAccelerationVoltageToRelativisticMass:
+    def test_zero(self):
+        mr = dpct.acceleration_voltage_to_relativistic_mass(0.0)
+        assert approx(mr) == sc.electron_mass
+
+    def test_200kv(self):
+        mr = dpct.acceleration_voltage_to_relativistic_mass(200000)
+        assert approx(mr) == 1.268e-30
+
+@pytest.mark.parametrize(
+    "av,wl", [(100000, 3.701e-12), (200000, 2.507e-12), (300000, 1.968e-12)]
+)  # V, pm
+def test_acceleration_voltage_to_wavelength(av, wl):
+    wavelength = dt.acceleration_voltage_to_wavelength(av)
+    assert approx(wavelength, rel=0.001, abs=0.0) == wl
+
+
+def test_acceleration_voltage_to_wavelength_array():
+    av = np.array([100000, 200000, 300000])  # In Volt
+    wavelength = dt.acceleration_voltage_to_wavelength(av)
+    wl = np.array([3.701e-12, 2.507e-12, 1.968e-12])  # In pm
+    assert len(wl) == 3
+    assert approx(wavelength, rel=0.001, abs=0.0) == wl
+
+
+class TestDiffractionScatteringAngle:
+    def test_simple(self):
+        # This should give ~9.84e-3 radians
+        acceleration_voltage = 300000
+        lattice_size = 2e-10  # 2 Ångstrøm (in meters)
+        miller_index = (1, 0, 0)
+        scattering_angle = dt.diffraction_scattering_angle(
+            acceleration_voltage, lattice_size, miller_index
+        )
+        assert approx(scattering_angle, rel=0.001) == 9.84e-3
+
+    @pytest.mark.parametrize(
+        "mi,sa",
+        [
+            ((1, 0, 0), 9.84e-3),
+            ((0, 1, 0), 9.84e-3),
+            ((0, 0, 1), 9.84e-3),
+            ((2, 0, 0), 19.68e-3),
+            ((0, 2, 0), 19.68e-3),
+            ((0, 0, 2), 19.68e-3),
+        ],
+    )
+    def test_miller_index(self, mi, sa):
+        acceleration_voltage = 300000
+        lattice_size = 2e-10  # 2 Ångstrøm (in meters)
+        scattering_angle = dt.diffraction_scattering_angle(
+            acceleration_voltage, lattice_size, mi
+        )
+        assert approx(scattering_angle, rel=0.001) == sa
+
+    def test_array_like(self):
+        # This should give ~9.84e-3 radians
+        acceleration_voltage = 300000
+        lattice_size = np.array([2e-10, 2e-10])
+        miller_index = (1, 0, 0)
+        scattering_angle = dt.diffraction_scattering_angle(
+            acceleration_voltage, lattice_size, miller_index
+        )
+        assert len(scattering_angle) == 2
+        sa_known = np.array([9.84e-3, 9.84e-3])
+        assert approx(scattering_angle, rel=0.001) == sa_known        

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -449,6 +449,7 @@ def uvtw_to_uvw(uvtw):
     common_factor = math.gcd(math.gcd(u, v), w)
     return tuple((int(x / common_factor)) for x in (u, v, w))
 
+
 def get_holz_angle(electron_wavelength, lattice_parameter):
     """
     Parameters
@@ -465,10 +466,10 @@ def get_holz_angle(electron_wavelength, lattice_parameter):
 
     Examples
     --------
-    >>> import pyxem.utils.radial_utils as ra
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> lattice_size = 0.3905 # STO-(001) in nm
     >>> wavelength = 2.51/1000 # Electron wavelength for 200 kV
-    >>> angle = ra._get_holz_angle(wavelength, lattice_size)
+    >>> angle = sim_utils.get_holz_angle(wavelength, lattice_size)
 
     """
     k0 = 1.0 / electron_wavelength
@@ -497,10 +498,10 @@ def scattering_angle_to_lattice_parameter(electron_wavelength, angle):
 
     Examples
     --------
-    >>> import pyxem.utils.radial_utils as ra
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> angle_list = [0.1, 0.1, 0.1, 0.1] # in radians
     >>> wavelength = 2.51/1000 # Electron wavelength for 200 kV
-    >>> lattice_size = ra._scattering_angle_to_lattice_parameter(
+    >>> lattice_size = sim_utils.scattering_angle_to_lattice_parameter(
     ...     wavelength, angle_list)
 
     """
@@ -508,6 +509,7 @@ def scattering_angle_to_lattice_parameter(electron_wavelength, angle):
     k0 = 1.0 / electron_wavelength
     kz = k0 - (k0 * ((1 - (np.sin(angle) ** 2)) ** 0.5))
     return 1 / kz
+
 
 def bst_to_beta(bst, acceleration_voltage):
     """Calculate beam deflection (beta) values from Bs * t.
@@ -527,10 +529,10 @@ def bst_to_beta(bst, acceleration_voltage):
     Examples
     --------
     >>> import numpy as np
-    >>> import pyxem.utils.dpc_utils as dpct
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> data = np.random.random((100, 100))  # In Tesla*meter
     >>> acceleration_voltage = 200000  # 200 kV (in Volt)
-    >>> beta = dpct.bst_to_beta(data, acceleration_voltage)
+    >>> beta = sim_utils.bst_to_beta(data, acceleration_voltage)
 
     """
     av = acceleration_voltage
@@ -558,10 +560,10 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
     Examples
     --------
     >>> import numpy as np
-    >>> import pyxem.utils.dpc_utils as dpct
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> data = np.random.random((100, 100))  # In radians
     >>> acceleration_voltage = 200000  # 200 kV (in Volt)
-    >>> bst = dpct.beta_to_bst(data, 200000)
+    >>> bst = sim_utils.beta_to_bst(data, 200000)
 
     """
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
@@ -587,9 +589,9 @@ def tesla_to_am(data):
     Examples
     --------
     >>> import numpy as np
-    >>> import pyxem.utils.dpc_utils as dpct
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> data_T = np.random.random((100, 100))  # In tesla
-    >>> data_am = dpct.tesla_to_am(data_T)
+    >>> data_am = sim_utils.tesla_to_am(data_T)
 
     """
     return data / sc.mu_0
@@ -610,8 +612,8 @@ def acceleration_voltage_to_velocity(acceleration_voltage):
 
     Example
     -------
-    >>> import pyxem.utils.dpc_utils as dpct
-    >>> v = dpct.acceleration_voltage_to_velocity(200000) # 200 kV
+    >>> import diffsims.utils.sim_utils as sim_utils
+    >>> v = sim_utils.acceleration_voltage_to_velocity(200000) # 200 kV
     >>> round(v)
     208450035
 
@@ -638,8 +640,8 @@ def acceleration_voltage_to_relativistic_mass(acceleration_voltage):
 
     Example
     -------
-    >>> import pyxem.utils.dpc_utils as dpct
-    >>> mr = dpct.acceleration_voltage_to_relativistic_mass(200000) # 200 kV
+    >>> import diffsims.utils.sim_utils as sim_utils
+    >>> mr = sim_utils.acceleration_voltage_to_relativistic_mass(200000) # 200 kV
 
     """
     av = acceleration_voltage
@@ -668,10 +670,10 @@ def et_to_beta(et, acceleration_voltage):
     Examples
     --------
     >>> import numpy as np
-    >>> import pyxem.utils.dpc_utils as dpct
+    >>> import diffsims.utils.sim_utils as sim_utils
     >>> data = np.random.random((100, 100))
     >>> acceleration_voltage = 200000  # 200 kV (in Volt)
-    >>> beta = dpct.et_to_beta(data, acceleration_voltage)
+    >>> beta = sim_utils.et_to_beta(data, acceleration_voltage)
 
     """
     av = acceleration_voltage
@@ -684,6 +686,7 @@ def et_to_beta(et, acceleration_voltage):
 
     beta = e * wavelength2 * m * et / h2
     return beta
+
 
 def acceleration_voltage_to_wavelength(acceleration_voltage):
     """Get electron wavelength from the acceleration voltage.
@@ -699,12 +702,12 @@ def acceleration_voltage_to_wavelength(acceleration_voltage):
         In meters
 
     """
-    E = acceleration_voltage*e
-    wavelength = h/(2*m_e*E*(1 + (E/(2*m_e*c**2))))**0.5
+    E = acceleration_voltage * e
+    wavelength = h / (2 * m_e * E * (1 + (E / (2 * m_e * c ** 2)))) ** 0.5
     return wavelength
 
-def diffraction_scattering_angle(
-        acceleration_voltage, lattice_size, miller_index):
+
+def diffraction_scattering_angle(acceleration_voltage, lattice_size, miller_index):
     """Get electron scattering angle from a crystal lattice.
 
     Returns the total scattering angle, as measured from the middle of the
@@ -733,6 +736,6 @@ def diffraction_scattering_angle(
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
     H, K, L = miller_index
     a = lattice_size
-    d = a/(H**2 + K**2 + L**2)**0.5
+    d = a / (H ** 2 + K ** 2 + L ** 2) ** 0.5
     scattering_angle = 2 * np.arcsin(wavelength / (2 * d))
     return scattering_angle

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -534,7 +534,6 @@ def bst_to_beta(bst, acceleration_voltage):
 
     """
     av = acceleration_voltage
-    ##removed dt.
     wavelength = acceleration_voltage_to_wavelength(av)
     ##removed defenitions of constants as defined at the top
     beta = e * wavelength * bst / h
@@ -565,7 +564,7 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
     >>> bst = dpct.beta_to_bst(data, 200000)
 
     """
-    wavelength = dt.acceleration_voltage_to_wavelength(acceleration_voltage)
+    wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
     beta = beam_deflection
 
     Bst = beta * h / (wavelength * e)
@@ -676,7 +675,6 @@ def et_to_beta(et, acceleration_voltage):
 
     """
     av = acceleration_voltage
-    ##removed dt.
     wavelength = acceleration_voltage_to_wavelength(av)
     m = acceleration_voltage_to_relativistic_mass(av)
     ##removed defenitions of constants as defined at the top

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -449,7 +449,7 @@ def uvtw_to_uvw(uvtw):
     common_factor = math.gcd(math.gcd(u, v), w)
     return tuple((int(x / common_factor)) for x in (u, v, w))
 
-def _get_holz_angle(electron_wavelength, lattice_parameter):
+def get_holz_angle(electron_wavelength, lattice_parameter):
     """
     Parameters
     ----------
@@ -479,7 +479,7 @@ def _get_holz_angle(electron_wavelength, lattice_parameter):
     return angle
 
 
-def _scattering_angle_to_lattice_parameter(electron_wavelength, angle):
+def scattering_angle_to_lattice_parameter(electron_wavelength, angle):
     """Convert scattering angle data to lattice parameter sizes.
 
     Parameters

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -19,7 +19,7 @@
 import math
 
 import numpy as np
-from scipy.constants import h, m_e, e, c, pi
+from scipy.constants import h, m_e, e, c, pi, mu_0
 import collections
 import diffpy.structure
 
@@ -451,7 +451,7 @@ def uvtw_to_uvw(uvtw):
 
 
 def get_holz_angle(electron_wavelength, lattice_parameter):
-    """
+    """ Converts electron wavelength and lattice paramater to holz angle
     Parameters
     ----------
     electron_wavelength : scalar
@@ -476,7 +476,7 @@ def get_holz_angle(electron_wavelength, lattice_parameter):
     kz = 1.0 / lattice_parameter
     in_root = kz * ((2 * k0) - kz)
     sin_angle = (in_root ** 0.5) / k0
-    angle = math.asin(sin_angle)
+    angle = np.arcsin(sin_angle)
     return angle
 
 
@@ -554,7 +554,7 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
 
     Returns
     -------
-    Bst : NumPy array
+    bst : NumPy array
         In Tesla * meter
 
     Examples
@@ -569,8 +569,8 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
     beta = beam_deflection
 
-    Bst = beta * h / (wavelength * e)
-    return Bst
+    bst = beta * h / (wavelength * e)
+    return bst
 
 
 def tesla_to_am(data):
@@ -594,7 +594,7 @@ def tesla_to_am(data):
     >>> data_am = sim_utils.tesla_to_am(data_T)
 
     """
-    return data / sc.mu_0
+    return data / mu_0
 
 
 def acceleration_voltage_to_velocity(acceleration_voltage):
@@ -676,15 +676,10 @@ def et_to_beta(et, acceleration_voltage):
     >>> beta = sim_utils.et_to_beta(data, acceleration_voltage)
 
     """
-    av = acceleration_voltage
-    wavelength = acceleration_voltage_to_wavelength(av)
-    m = acceleration_voltage_to_relativistic_mass(av)
-    ##removed defenitions of constants as defined at the top
+    wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
+    m = acceleration_voltage_to_relativistic_mass(acceleration_voltage)
 
-    wavelength2 = wavelength ** 2
-    h2 = h ** 2
-
-    beta = e * wavelength2 * m * et / h2
+    beta = e * (wavelength ** 2) * m * et / (h ** 2)
     return beta
 
 
@@ -702,8 +697,8 @@ def acceleration_voltage_to_wavelength(acceleration_voltage):
         In meters
 
     """
-    E = acceleration_voltage * e
-    wavelength = h / (2 * m_e * E * (1 + (E / (2 * m_e * c ** 2)))) ** 0.5
+    energy = acceleration_voltage * e
+    wavelength = h / (2 * m_e * energy * (1 + (energy / (2 * m_e * c ** 2)))) ** 0.5
     return wavelength
 
 
@@ -734,8 +729,8 @@ def diffraction_scattering_angle(acceleration_voltage, lattice_size, miller_inde
 
     """
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
-    H, K, L = miller_index
+    h, k, l = miller_index
     a = lattice_size
-    d = a / (H ** 2 + K ** 2 + L ** 2) ** 0.5
+    d = a / (h ** 2 + k ** 2 + l ** 2) ** 0.5
     scattering_angle = 2 * np.arcsin(wavelength / (2 * d))
     return scattering_angle

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -74,9 +74,8 @@ def get_interaction_constant(accelerating_voltage):
         The relativistic electron wavelength in m.
 
     """
-    E = accelerating_voltage
     wavelength = get_electron_wavelength(accelerating_voltage)
-    sigma = 2 * pi * (m_e + e * E)
+    sigma = 2 * pi * (m_e + e * accelerating_voltage)
 
     return sigma
 
@@ -535,8 +534,7 @@ def bst_to_beta(bst, acceleration_voltage):
     >>> beta = sim_utils.bst_to_beta(data, acceleration_voltage)
 
     """
-    av = acceleration_voltage
-    wavelength = acceleration_voltage_to_wavelength(av)
+    wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
     ##removed defenitions of constants as defined at the top
     beta = e * wavelength * bst / h
     return beta
@@ -569,8 +567,8 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
     beta = beam_deflection
 
-    bst = beta * h / (wavelength * e)
-    return bst
+    mag_field = beta * h / (wavelength * e)
+    return mag_field
 
 
 def tesla_to_am(data):
@@ -618,9 +616,8 @@ def acceleration_voltage_to_velocity(acceleration_voltage):
     208450035
 
     """
-    av = acceleration_voltage
-    ##removed defenitions of constants as defined at the top
-    part1 = (1 + (av * e) / (m_e * c ** 2)) ** 2
+
+    part1 = (1 + (acceleration_voltage * e) / (m_e * c ** 2)) ** 2
     v = c * (1 - (1 / part1)) ** 0.5
     return v
 
@@ -644,9 +641,8 @@ def acceleration_voltage_to_relativistic_mass(acceleration_voltage):
     >>> mr = sim_utils.acceleration_voltage_to_relativistic_mass(200000) # 200 kV
 
     """
-    av = acceleration_voltage
     ##removed defenitions of constants as defined at the top
-    v = acceleration_voltage_to_velocity(av)
+    v = acceleration_voltage_to_velocity(acceleration_voltage)
     part1 = 1 - (v ** 2) / (c ** 2)
     mr = m_e / (part1) ** 0.5
     return mr

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -448,3 +448,297 @@ def uvtw_to_uvw(uvtw):
     u, v, w = 2 * u + v, 2 * v + u, w
     common_factor = math.gcd(math.gcd(u, v), w)
     return tuple((int(x / common_factor)) for x in (u, v, w))
+
+def _get_holz_angle(electron_wavelength, lattice_parameter):
+    """
+    Parameters
+    ----------
+    electron_wavelength : scalar
+        In nanometers
+    lattice_parameter : scalar
+        In nanometers
+
+    Returns
+    -------
+    scattering_angle : scalar
+        Scattering angle in radians
+
+    Examples
+    --------
+    >>> import pyxem.utils.radial_utils as ra
+    >>> lattice_size = 0.3905 # STO-(001) in nm
+    >>> wavelength = 2.51/1000 # Electron wavelength for 200 kV
+    >>> angle = ra._get_holz_angle(wavelength, lattice_size)
+
+    """
+    k0 = 1.0 / electron_wavelength
+    kz = 1.0 / lattice_parameter
+    in_root = kz * ((2 * k0) - kz)
+    sin_angle = (in_root ** 0.5) / k0
+    angle = math.asin(sin_angle)
+    return angle
+
+
+def _scattering_angle_to_lattice_parameter(electron_wavelength, angle):
+    """Convert scattering angle data to lattice parameter sizes.
+
+    Parameters
+    ----------
+    electron_wavelength : float
+        Wavelength of the electrons in the electron beam. In nm.
+        For 200 kV electrons: 0.00251 (nm)
+    angle : NumPy array
+        Scattering angle, in radians.
+
+    Returns
+    -------
+    lattice_parameter : NumPy array
+        Lattice parameter, in nanometers
+
+    Examples
+    --------
+    >>> import pyxem.utils.radial_utils as ra
+    >>> angle_list = [0.1, 0.1, 0.1, 0.1] # in radians
+    >>> wavelength = 2.51/1000 # Electron wavelength for 200 kV
+    >>> lattice_size = ra._scattering_angle_to_lattice_parameter(
+    ...     wavelength, angle_list)
+
+    """
+
+    k0 = 1.0 / electron_wavelength
+    kz = k0 - (k0 * ((1 - (np.sin(angle) ** 2)) ** 0.5))
+    return 1 / kz
+
+def bst_to_beta(bst, acceleration_voltage):
+    """Calculate beam deflection (beta) values from Bs * t.
+
+    Parameters
+    ----------
+    bst : NumPy array
+        Saturation induction Bs times thickness t of the sample. In Tesla*meter
+    acceleration_voltage : float
+        In Volts
+
+    Returns
+    -------
+    beta : NumPy array
+        Beam deflection in radians
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> data = np.random.random((100, 100))  # In Tesla*meter
+    >>> acceleration_voltage = 200000  # 200 kV (in Volt)
+    >>> beta = dpct.bst_to_beta(data, acceleration_voltage)
+
+    """
+    av = acceleration_voltage
+    wavelength = dt.acceleration_voltage_to_wavelength(av)
+    e = sc.elementary_charge
+    h = sc.Planck
+    beta = e * wavelength * bst / h
+    return beta
+
+
+def beta_to_bst(beam_deflection, acceleration_voltage):
+    """Calculate Bs * t values from beam deflection (beta).
+
+    Parameters
+    ----------
+    beam_deflection : NumPy array
+        In radians
+    acceleration_voltage : float
+        In Volts
+
+    Returns
+    -------
+    Bst : NumPy array
+        In Tesla * meter
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> data = np.random.random((100, 100))  # In radians
+    >>> acceleration_voltage = 200000  # 200 kV (in Volt)
+    >>> bst = dpct.beta_to_bst(data, 200000)
+
+    """
+    wavelength = dt.acceleration_voltage_to_wavelength(acceleration_voltage)
+    beta = beam_deflection
+    e = sc.elementary_charge
+    h = sc.Planck
+    Bst = beta * h / (wavelength * e)
+    return Bst
+
+
+def tesla_to_am(data):
+    """Convert data from Tesla to A/m
+
+    Parameters
+    ----------
+    data : NumPy array
+        Data in Tesla
+
+    Returns
+    -------
+    output_data : NumPy array
+        In A/m
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> data_T = np.random.random((100, 100))  # In tesla
+    >>> data_am = dpct.tesla_to_am(data_T)
+
+    """
+    return data / sc.mu_0
+
+
+def acceleration_voltage_to_velocity(acceleration_voltage):
+    """Get relativistic velocity of electron from acceleration voltage.
+
+    Parameters
+    ----------
+    acceleration_voltage : float
+        In Volt
+
+    Returns
+    -------
+    v : float
+        In m/s
+
+    Example
+    -------
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> v = dpct.acceleration_voltage_to_velocity(200000) # 200 kV
+    >>> round(v)
+    208450035
+
+    """
+    c = sc.speed_of_light
+    av = acceleration_voltage
+    e = sc.elementary_charge
+    me = sc.electron_mass
+    part1 = (1 + (av * e) / (me * c ** 2)) ** 2
+    v = c * (1 - (1 / part1)) ** 0.5
+    return v
+
+
+def acceleration_voltage_to_relativistic_mass(acceleration_voltage):
+    """Get relativistic mass of electron as function of acceleration voltage.
+
+    Parameters
+    ----------
+    acceleration_voltage : float
+        In Volt
+
+    Returns
+    -------
+    mr : float
+        Relativistic electron mass
+
+    Example
+    -------
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> mr = dpct.acceleration_voltage_to_relativistic_mass(200000) # 200 kV
+
+    """
+    av = acceleration_voltage
+    c = sc.speed_of_light
+    v = acceleration_voltage_to_velocity(av)
+    me = sc.electron_mass
+    part1 = 1 - (v ** 2) / (c ** 2)
+    mr = me / (part1) ** 0.5
+    return mr
+
+
+def et_to_beta(et, acceleration_voltage):
+    """Calculate beam deflection (beta) values from E * t.
+
+    Parameters
+    ----------
+    et : NumPy array
+        Electric field times thickness t of the sample.
+    acceleration_voltage : float
+        In Volts
+
+    Returns
+    -------
+    beta: NumPy array
+        Beam deflection in radians
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pyxem.utils.dpc_utils as dpct
+    >>> data = np.random.random((100, 100))
+    >>> acceleration_voltage = 200000  # 200 kV (in Volt)
+    >>> beta = dpct.et_to_beta(data, acceleration_voltage)
+
+    """
+    av = acceleration_voltage
+    e = sc.elementary_charge
+    wavelength = dt.acceleration_voltage_to_wavelength(av)
+    m = acceleration_voltage_to_relativistic_mass(av)
+    h = sc.Planck
+
+    wavelength2 = wavelength ** 2
+    h2 = h ** 2
+
+    beta = e * wavelength2 * m * et / h2
+    return beta
+
+def acceleration_voltage_to_wavelength(acceleration_voltage):
+    """Get electron wavelength from the acceleration voltage.
+
+    Parameters
+    ----------
+    acceleration_voltage : float or array-like
+        In Volt
+
+    Returns
+    -------
+    wavelength : float or array-like
+        In meters
+
+    """
+    E = acceleration_voltage*e
+    wavelength = h/(2*m_e*E*(1 + (E/(2*m_e*c**2))))**0.5
+    return wavelength
+
+def diffraction_scattering_angle(
+        acceleration_voltage, lattice_size, miller_index):
+    """Get electron scattering angle from a crystal lattice.
+
+    Returns the total scattering angle, as measured from the middle of the
+    direct beam (0, 0, 0) to the given Miller index.
+
+    Miller index: h, k, l = miller_index
+    Interplanar distance: d = a / (h**2 + k**2 + l**2)**0.5
+    Bragg's law: theta = arcsin(electron_wavelength / (2 * d))
+    Total scattering angle (phi):  phi = 2 * theta
+
+    Parameters
+    ----------
+    acceleration_voltage : float
+        In Volt
+    lattice_size : float or array-like
+        In meter
+    miller_index : tuple
+        (h, k, l)
+
+    Returns
+    -------
+    angle : float
+        Scattering angle in radians.
+
+    """
+    wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
+    H, K, L = miller_index
+    a = lattice_size
+    d = a/(H**2 + K**2 + L**2)**0.5
+    scattering_angle = 2 * np.arcsin(wavelength / (2 * d))
+    return scattering_angle

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -535,7 +535,6 @@ def bst_to_beta(bst, acceleration_voltage):
 
     """
     wavelength = acceleration_voltage_to_wavelength(acceleration_voltage)
-    ##removed defenitions of constants as defined at the top
     beta = e * wavelength * bst / h
     return beta
 
@@ -641,7 +640,6 @@ def acceleration_voltage_to_relativistic_mass(acceleration_voltage):
     >>> mr = sim_utils.acceleration_voltage_to_relativistic_mass(200000) # 200 kV
 
     """
-    ##removed defenitions of constants as defined at the top
     v = acceleration_voltage_to_velocity(acceleration_voltage)
     part1 = 1 - (v ** 2) / (c ** 2)
     mr = m_e / (part1) ** 0.5

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -534,9 +534,9 @@ def bst_to_beta(bst, acceleration_voltage):
 
     """
     av = acceleration_voltage
-    wavelength = dt.acceleration_voltage_to_wavelength(av)
-    e = sc.elementary_charge
-    h = sc.Planck
+    ##removed dt.
+    wavelength = acceleration_voltage_to_wavelength(av)
+    ##removed defenitions of constants as defined at the top
     beta = e * wavelength * bst / h
     return beta
 
@@ -567,8 +567,7 @@ def beta_to_bst(beam_deflection, acceleration_voltage):
     """
     wavelength = dt.acceleration_voltage_to_wavelength(acceleration_voltage)
     beta = beam_deflection
-    e = sc.elementary_charge
-    h = sc.Planck
+
     Bst = beta * h / (wavelength * e)
     return Bst
 
@@ -618,11 +617,9 @@ def acceleration_voltage_to_velocity(acceleration_voltage):
     208450035
 
     """
-    c = sc.speed_of_light
     av = acceleration_voltage
-    e = sc.elementary_charge
-    me = sc.electron_mass
-    part1 = (1 + (av * e) / (me * c ** 2)) ** 2
+    ##removed defenitions of constants as defined at the top
+    part1 = (1 + (av * e) / (m_e * c ** 2)) ** 2
     v = c * (1 - (1 / part1)) ** 0.5
     return v
 
@@ -647,11 +644,10 @@ def acceleration_voltage_to_relativistic_mass(acceleration_voltage):
 
     """
     av = acceleration_voltage
-    c = sc.speed_of_light
+    ##removed defenitions of constants as defined at the top
     v = acceleration_voltage_to_velocity(av)
-    me = sc.electron_mass
     part1 = 1 - (v ** 2) / (c ** 2)
-    mr = me / (part1) ** 0.5
+    mr = m_e / (part1) ** 0.5
     return mr
 
 
@@ -680,10 +676,10 @@ def et_to_beta(et, acceleration_voltage):
 
     """
     av = acceleration_voltage
-    e = sc.elementary_charge
-    wavelength = dt.acceleration_voltage_to_wavelength(av)
+    ##removed dt.
+    wavelength = acceleration_voltage_to_wavelength(av)
     m = acceleration_voltage_to_relativistic_mass(av)
-    h = sc.Planck
+    ##removed defenitions of constants as defined at the top
 
     wavelength2 = wavelength ** 2
     h2 = h ** 2


### PR DESCRIPTION
Have moved over the following functions from pixstem;

get_holtz_angle
scattering_angle_to_lattice_parameter
bst_to_beta
beta_to_bst
tesla_to_am
acceleration_voltage_to_velocity
acceleration_voltage_to_reduced_mass
et_to_beta
acceleration_voltage_to_wavelength
diffraction_scattering_angle ##had to change some constants here to fit with the diffsims constants defenitions at the top.

I will move the tests over into diffsims/tests/test_utils/test_sim_utils.py seperatley. 




