### PR TITLE
Specify module import structure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,10 @@ If you know there is more to do, make a checklist here:
 - [ ] TODO 1
 - [ ] TODO 2
 
-
+#### For reviewers
+<!-- Don't remove the checklist below. -->
+- [ ] Check that the PR title is short, concise, and will make sense 1 year
+  later.
+- [ ] Check that new functions are imported in corresponding `__init__.py`.
+- [ ] Check that new features, API changes, and deprecations are mentioned in
+      the unreleased section in `CHANGELOG.md`.

--- a/diffsims/__init__.py
+++ b/diffsims/__init__.py
@@ -18,19 +18,7 @@
 
 import logging
 
-from .generators.diffraction_generator import (
-    DiffractionGenerator,
-    AtomicDiffractionGenerator,
-)
-from .generators.library_generator import DiffractionLibraryGenerator
-from .generators.library_generator import VectorLibraryGenerator
-
-from .sims.diffraction_simulation import DiffractionSimulation
-
-from .crystallography import *  # What's imported is specified in the modules' init
-from .structure_factor import *  # What's imported is specified in the modules' init
-
-from . import release_info
+from diffsims import release_info
 
 __version__ = release_info.version
 __author__ = release_info.author

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -247,7 +247,10 @@ class ReciprocalLatticePoint:
         return self.__class__(phase=self.phase, hkl=unique_hkl)
 
     def symmetrise(
-        self, antipodal=True, unique=True, return_multiplicity=False,
+        self,
+        antipodal=True,
+        unique=True,
+        return_multiplicity=False,
     ):
         """Return planes with symmetrically equivalent Miller indices.
 
@@ -330,11 +333,16 @@ class ReciprocalLatticePoint:
         ):
             if method == "kinematical":
                 structure_factors[i] = get_kinematical_structure_factor(
-                    phase=self.phase, hkl=hkl, scattering_parameter=s,
+                    phase=self.phase,
+                    hkl=hkl,
+                    scattering_parameter=s,
                 )
             else:
                 structure_factors[i] = get_doyleturner_structure_factor(
-                    phase=self.phase, hkl=hkl, scattering_parameter=s, voltage=voltage,
+                    phase=self.phase,
+                    hkl=hkl,
+                    scattering_parameter=s,
+                    voltage=voltage,
                 )
         self._structure_factor = np.where(
             structure_factors < _FLOAT_EPS, 0, structure_factors

--- a/diffsims/generators/__init__.py
+++ b/diffsims/generators/__init__.py
@@ -15,3 +15,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Generation of diffraction simulations and libraries, and lists of
+rotations.
+"""
+
+from diffsims.generators import (
+    diffraction_generator,
+    library_generator,
+    rotation_list_generators,
+    sphere_mesh_generators,
+    zap_map_generator,
+)
+
+__all__ = [
+    "diffraction_generator",
+    "library_generator",
+    "rotation_list_generators",
+    "sphere_mesh_generators",
+    "zap_map_generator",
+]

--- a/diffsims/generators/zap_map_generator.py
+++ b/diffsims/generators/zap_map_generator.py
@@ -27,14 +27,14 @@ def get_rotation_from_z_to_direction(structure, direction):
     Parameters
     ----------
     structure : diffpy.structure.structure.Structure
-        The structure for which a rotation needs to be found
+        The structure for which a rotation needs to be found.
     direction : array like
         [UVW] direction that the 'z' axis should end up point down.
 
     Returns
     -------
     euler_angles : tuple
-        'rzxz' in degrees
+        'rzxz' in degrees.
 
     See Also
     --------
@@ -71,15 +71,12 @@ def generate_directional_simulations(
 
     Parameters
     ----------
-    structure : diffpy.structure
-        The structure from which simulations need to be produced
-
+    structure : diffpy.structure.structure.Structure
+        The structure from which simulations need to be produced.
     simulator : DiffractionGenerator
         The diffraction generator object used to produce the simulations
-
     direction_list : list of lists
         A list of [UVW] indices, eg. [[1,0,0],[1,1,0]]
-
     reciprocal_radius : float
         Default to 1
 
@@ -155,8 +152,8 @@ def generate_zap_map(
     zap_dictionary : dict
         Keys are zone axes, values are simulations
 
-    Example
-    -------
+    Examples
+    --------
     Plot all of the patterns that you have generated
 
     >>> zap_map = generate_zap_map(structure,simulator,'hexagonal',density='3')

--- a/diffsims/libraries/__init__.py
+++ b/diffsims/libraries/__init__.py
@@ -15,3 +15,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Diffraction, structure and vector libraries."""
+
+from diffsims.libraries import (
+    diffraction_library,
+    structure_library,
+    vector_library,
+)
+
+__all__ = [
+    "diffraction_library",
+    "structure_library",
+    "vector_library",
+]

--- a/diffsims/sims/__init__.py
+++ b/diffsims/sims/__init__.py
@@ -15,3 +15,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Diffraction simulations."""
+
+from diffsims.sims import (
+    diffraction_simulation,
+)
+
+__all__ = [
+    "diffraction_simulation",
+]

--- a/diffsims/structure_factor/atomic_scattering_factor.py
+++ b/diffsims/structure_factor/atomic_scattering_factor.py
@@ -34,7 +34,7 @@ def get_kinematical_atomic_scattering_factor(atom, scattering_parameter):
 
     Parameters
     ----------
-    atom : diffpy.structure.Atom
+    atom : diffpy.structure.atom.Atom
         Atom with element type, Debye-Waller factor and occupancy number.
     scattering_parameter : float
         The scattering parameter s for these Miller indices describing
@@ -75,7 +75,7 @@ def get_doyleturner_atomic_scattering_factor(
 
     Parameters
     ----------
-    atom : diffpy.structure.Atom
+    atom : diffpy.structure.atom.Atom
         Atom with element type, Debye-Waller factor and occupancy number.
     scattering_parameter : float
         The scattering parameter s for these Miller indices describing

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -157,9 +157,9 @@ def get_atomic_scattering_parameters(element, unit=None):
 
     Returns
     -------
-    a : np.ndarray
+    a : numpy.ndarray
         The four atomic scattering parameters a_1-4.
-    b : np.ndarray
+    b : numpy.ndarray
         The four atomic scattering parameters b_1-4.
 
     References

--- a/diffsims/structure_factor/structure_factor.py
+++ b/diffsims/structure_factor/structure_factor.py
@@ -38,12 +38,12 @@ def find_asymmetric_positions(positions, space_group):
     ----------
     positions : list
         A list of cartesian atom positions.
-    space_group : diffpy.structure.spacegroups.SpaceGroup
+    space_group : diffpy.structure.spacegroupmod.SpaceGroup
         Space group describing the symmetry operations.
 
     Returns
     -------
-    np.ndarray
+    numpy.ndarray
         Asymmetric atom positions.
     """
     asymmetric_positions = SymmetryConstraints(space_group, positions).corepos
@@ -67,7 +67,7 @@ def get_kinematical_structure_factor(phase, hkl, scattering_parameter):
     phase : orix.crystal_map.phase_list.Phase
         A phase container with a crystal structure and a space and point
         group describing the allowed symmetry operations.
-    hkl : np.ndarray or list
+    hkl : numpy.ndarray or list
         Miller indices.
     scattering_parameter : float
         Scattering parameter for these Miller indices.
@@ -102,7 +102,11 @@ def get_kinematical_structure_factor(phase, hkl, scattering_parameter):
 
 
 def get_doyleturner_structure_factor(
-    phase, hkl, scattering_parameter, voltage, return_parameters=False,
+    phase,
+    hkl,
+    scattering_parameter,
+    voltage,
+    return_parameters=False,
 ):
     """Return the structure factor for a given family of Miller indices
     using Doyle-Turner atomic scattering parameters [Doyle1968]_.
@@ -117,7 +121,7 @@ def get_doyleturner_structure_factor(
     phase : orix.crystal_map.phase_list.Phase
         A phase container with a crystal structure and a space and point
         group describing the allowed symmetry operations.
-    hkl : np.ndarray or list
+    hkl : numpy.ndarray or list
         Miller indices.
     scattering_parameter : float
         Scattering parameter for these Miller indices.

--- a/diffsims/utils/__init__.py
+++ b/diffsims/utils/__init__.py
@@ -15,3 +15,35 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Diffraction utilities used by the other modules."""
+
+from diffsims.utils import (
+    atomic_diffraction_generator_utils,
+    atomic_scattering_params,
+    discretise_utils,
+    fourier_transform,
+    generic_utils,
+    kinematic_simulation_utils,
+    lobato_scattering_params,
+    probe_utils,
+    scattering_params,
+    shape_factor_models,
+    sim_utils,
+    vector_utils,
+)
+
+__all__ = [
+    "atomic_diffraction_generator_utils",
+    "atomic_scattering_params",
+    "discretise_utils",
+    "fourier_transform",
+    "generic_utils",
+    "kinematic_simulation_utils",
+    "lobato_scattering_params",
+    "probe_utils",
+    "scattering_params",
+    "shape_factor_models",
+    "sim_utils",
+    "vector_utils",
+]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ from diffsims import __author__, __version__, __file__
 
 # -- Project information -----------------------------------------------------
 
-project = 'diffsims'
+project = "diffsims"
 copyright = f"2018-{str(datetime.now().year)}, {__author__}"
 author = __author__
 
@@ -58,12 +58,12 @@ intersphinx_mapping = {
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -71,16 +71,17 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Logo
-#html_logo = "_static/img/diffsims_logo.png"
-#html_favicon = "_static/img/diffsims_logo.png"
+# html_logo = "_static/img/diffsims_logo.png"
+# html_favicon = "_static/img/diffsims_logo.png"
+
 
 def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -3,7 +3,7 @@ API reference
 =============
 
 This reference manual details the public classes, modules and functions in diffsims as
-generated from their docstrings. Many of the docstrings contain examples.
+generated from their docstrings. Some of the docstrings contain examples.
 
 .. caution::
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

---
name: Specify module import structure
about: Maintenance update that specifies a module import structure
---

**Release Notes**
> developer change
Summary: Specify module import structure

**What does this PR do? Please describe and/or link to an open issue.**
* Specifies a module import structure, import stuff in modules' init instead of the top init `diffsims/__init__.py`. Nothing except package metadata, like version, is now importable from just diffsims; everything has to imported from a module, like `from diffsims.crystallography import ReciprocalLatticePoint`.
* Fix some docstring formatting for Readthedocs.
* Add reviewer section in PR template to ensure the changelog is updated if necessary, and that new functionality is imported in a module's init.

@pc494, how come your Black formatting is different from mine? I see that in a previous clean up PR of yours, some of my function signatures got formatted by you, and now my Black formats it back...

**Work in progress?**
- [x] Check whether changes in the import structure affects pyxem.