### PR TITLE
Adding support for beam precession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- get_grid_beam_directions, now works based off of meshes
+- `get_grid_beam_directions`, now works based off of meshes
+- the arguments in the `DiffractionGenerator` constructor and the `DiffractionLibraryGenerator.get_diffraction_library` function have been shuffled so that the former captures arguments related to "the instrument/physics" while the latter captures arguments relevant to "the sample/material".
 
 ### Added
 - API reference documentation via Read The Docs: https://diffsims.rtfd.io
-- New module: "sphere_mesh_generators"
+- New module: `sphere_mesh_generators`
+- beam precession is now supported in simulating electron diffraction patterns
+- more shape factor functions have been added
 - This project now keeps a Changelog
 
 ### Removed

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -357,7 +357,8 @@ class DiffractionGenerator(object):
         )
 
     def calculate_profile_data(
-        self, structure, reciprocal_radius=1.0, minimum_intensity=1e-3
+        self, structure, reciprocal_radius=1.0, minimum_intensity=1e-3,
+        debye_waller_factors={}
     ):
         """Calculates a one dimensional diffraction profile for a
         structure.
@@ -372,6 +373,8 @@ class DiffractionGenerator(object):
         minimum_intensity : float
             The minimum intensity required for a diffraction peak to be
             considered real. Deals with numerical precision issues.
+        debye_waller_factors : dict of str:value pairs
+            Maps element names to their temperature-dependent Debye-Waller factors.
 
         Returns
         -------
@@ -399,7 +402,7 @@ class DiffractionGenerator(object):
             np.asarray(g_hkls),
             prefactor=multiplicities,
             scattering_params=self.scattering_params,
-            debye_waller_factors=self.debye_waller_factors,
+            debye_waller_factors=debye_waller_factors,
         )
 
         if is_lattice_hexagonal(latt):

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -208,7 +208,7 @@ class DiffractionGenerator(object):
         accelerating_voltage,
         scattering_params="lobato",
         precession_angle=0,
-        shape_factor_model="linear",
+        shape_factor_model="lorentzian",
         approximate_precession=True,
         minimum_intensity=1e-20,
         **kwargs,

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -289,16 +289,15 @@ class DiffractionGenerator(object):
         r_spot = np.sqrt(np.sum(np.square(cartesian_coordinates[:, :2]), axis=1))
         z_spot = cartesian_coordinates[:, 2]
 
-        if self.precession_angle > 0:
-            if not self.approximate_precession:
-                # We find the average excitation error - this step can be
-                # quite expensive
-                excitation_error = _average_excitation_error_precession(
-                        z_spot,
-                        r_spot,
-                        wavelength,
-                        self.precession_angle,
-                        )
+        if self.precession_angle > 0 and not self.approximate_precession:
+            # We find the average excitation error - this step can be
+            # quite expensive
+            excitation_error = _average_excitation_error_precession(
+                    z_spot,
+                    r_spot,
+                    wavelength,
+                    self.precession_angle,
+                    )
         else:
             z_sphere = -np.sqrt(r_sphere ** 2 - r_spot ** 2) + r_sphere
             excitation_error = z_sphere - z_spot
@@ -317,7 +316,7 @@ class DiffractionGenerator(object):
                     wavelength,
                     self.precession_angle,
                     self.shape_factor_model,
-                    self.max_excitation_error,
+                    max_excitation_error,
                     **self.shape_factor_kwargs,
                     )
         elif self.precession_angle > 0 and self.approximate_precession:

--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -111,7 +111,7 @@ class DiffractionLibraryGenerator:
                     rotation=orientation,
                     with_direct_beam=with_direct_beam,
                     max_excitation_error=max_excitation_error,
-                    debye_waller_factors=debye_waller_factors
+                    debye_waller_factors=debye_waller_factors,
                 )
 
                 # Calibrate simulation
@@ -126,11 +126,11 @@ class DiffractionLibraryGenerator:
                 intensities[i] = simulation.intensities
 
             diffraction_library[phase_name] = {
-                 "simulations": simulations,
-                 "orientations": orientations,
-                 "pixel_coords": pixel_coords,
-                 "intensities": intensities,
-             }
+                "simulations": simulations,
+                "orientations": orientations,
+                "pixel_coords": pixel_coords,
+                "intensities": intensities,
+            }
         # Pass attributes to diffraction library from structure library.
         diffraction_library.identifiers = structure_library.identifiers
         diffraction_library.structures = structure_library.structures

--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -51,6 +51,8 @@ class DiffractionLibraryGenerator:
         reciprocal_radius,
         half_shape,
         with_direct_beam=True,
+        max_excitation_error=1e-2,
+        debye_waller_factors={},
     ):
         """Calculates a dictionary of diffraction data for a library of crystal
         structures and orientations.
@@ -74,6 +76,11 @@ class DiffractionLibraryGenerator:
             The half shape of the target patterns, for 144x144 use (72,72) etc
         with_direct_beam : bool
             Include the direct beam in the library.
+        max_excitation_error : float
+            The extinction distance for reflections, in reciprocal
+            Angstroms.
+        debye_waller_factors : dict of str:value pairs
+            Maps element names to their temperature-dependent Debye-Waller factors.
 
         Returns
         -------
@@ -103,6 +110,8 @@ class DiffractionLibraryGenerator:
                     reciprocal_radius,
                     rotation=orientation,
                     with_direct_beam=with_direct_beam,
+                    max_excitation_error=max_excitation_error,
+                    debye_waller_factors=debye_waller_factors
                 )
 
                 # Calibrate simulation
@@ -117,12 +126,11 @@ class DiffractionLibraryGenerator:
                 intensities[i] = simulation.intensities
 
             diffraction_library[phase_name] = {
-                "simulations": simulations,
-                "orientations": orientations,
-                "pixel_coords": pixel_coords,
-                "intensities": intensities,
-            }
-
+                 "simulations": simulations,
+                 "orientations": orientations,
+                 "pixel_coords": pixel_coords,
+                 "intensities": intensities,
+             }
         # Pass attributes to diffraction library from structure library.
         diffraction_library.identifiers = structure_library.identifiers
         diffraction_library.structures = structure_library.structures

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -481,5 +481,5 @@ def beam_directions_grid_to_euler(vectors):
     phi2 = sign * np.nan_to_num(np.arccos(x_comp / norm_proj))
     # phi1 is just 0, rotation around z''
     phi1 = np.zeros(phi2.shape[0])
-    grid = np.rad2deg(np.vstack([phi1, Phi, np.pi/2 - phi2]).T)
+    grid = np.rad2deg(np.vstack([phi1, Phi, np.pi / 2 - phi2]).T)
     return grid

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -481,5 +481,5 @@ def beam_directions_grid_to_euler(vectors):
     phi2 = sign * np.nan_to_num(np.arccos(x_comp / norm_proj))
     # phi1 is just 0, rotation around z''
     phi1 = np.zeros(phi2.shape[0])
-    grid = np.rad2deg(np.vstack([phi1, Phi, phi2]).T)
+    grid = np.rad2deg(np.vstack([phi1, Phi, np.pi/2 - phi2]).T)
     return grid

--- a/diffsims/tests/test_generators/test_diffraction_generator.py
+++ b/diffsims/tests/test_generators/test_diffraction_generator.py
@@ -146,7 +146,7 @@ class TestDiffractionCalculator:
     def test_init(self, diffraction_calculator: DiffractionGenerator):
         assert diffraction_calculator.scattering_params == "lobato"
         assert diffraction_calculator.precession_angle == 0
-        assert diffraction_calculator.shape_factor_model == linear
+        assert diffraction_calculator.shape_factor_model == lorentzian
         assert diffraction_calculator.approximate_precession == True
         assert diffraction_calculator.minimum_intensity == 1e-20
 

--- a/diffsims/tests/test_generators/test_diffraction_generator.py
+++ b/diffsims/tests/test_generators/test_diffraction_generator.py
@@ -28,8 +28,7 @@ from diffsims.generators.diffraction_generator import (
     _average_excitation_error_precession,
 )
 import diffpy.structure
-from diffsims.utils.shape_factor_models import (linear, binary, sin2c,
-                                                atanc, lorentzian)
+from diffsims.utils.shape_factor_models import linear, binary, sin2c, atanc, lorentzian
 
 
 @pytest.fixture(params=[(300)])
@@ -39,14 +38,12 @@ def diffraction_calculator(request):
 
 @pytest.fixture(scope="module")
 def diffraction_calculator_precession_full():
-    return DiffractionGenerator(300, precession_angle=0.5,
-                                approximate_precession=False)
+    return DiffractionGenerator(300, precession_angle=0.5, approximate_precession=False)
 
 
 @pytest.fixture(scope="module")
 def diffraction_calculator_precession_simple():
-    return DiffractionGenerator(300, precession_angle=0.5,
-                                approximate_precession=True)
+    return DiffractionGenerator(300, precession_angle=0.5, approximate_precession=True)
 
 
 def local_excite(excitation_error, maximum_excitation_error, t):
@@ -55,9 +52,7 @@ def local_excite(excitation_error, maximum_excitation_error, t):
 
 @pytest.fixture(scope="module")
 def diffraction_calculator_custom():
-    return DiffractionGenerator(300,
-                                shape_factor_model=local_excite,
-                                t=0.2)
+    return DiffractionGenerator(300, shape_factor_model=local_excite, t=0.2)
 
 
 @pytest.fixture(params=[(300, [np.linspace(-1, 1, 10)] * 2)])
@@ -109,11 +104,17 @@ def probe(x, out=None, scale=None):
         return v + 0 * x[2].reshape(1, 1, -1)
 
 
-@pytest.mark.parametrize("parameters, expected",
-                         [([0, 1, 0.001, 0.5], -0.00822681491001731),
-                          ([0, np.array([1, 2, 20]), 0.001, 0.5],
-                            np.array([-0.00822681, -0.01545354, 0.02547058])),
-                          ([180, 1, 0.001, 0.5], 0.00922693)])
+@pytest.mark.parametrize(
+    "parameters, expected",
+    [
+        ([0, 1, 0.001, 0.5], -0.00822681491001731),
+        (
+            [0, np.array([1, 2, 20]), 0.001, 0.5],
+            np.array([-0.00822681, -0.01545354, 0.02547058]),
+        ),
+        ([180, 1, 0.001, 0.5], 0.00922693),
+    ],
+)
 def test_z_sphere_precession(parameters, expected):
     result = _z_sphere_precession(*parameters)
     assert np.allclose(result, expected)
@@ -132,10 +133,10 @@ def test_average_excitation_error_precession():
     _ = _average_excitation_error_precession(z, r, 0.001, 0.5)
 
 
-@pytest.mark.parametrize("model, expected",
-                         [("linear", linear),
-                          ("lorentzian", lorentzian),
-                          (binary, binary)],)
+@pytest.mark.parametrize(
+    "model, expected",
+    [("linear", linear), ("lorentzian", lorentzian), (binary, binary)],
+)
 def test_diffraction_generator_init(model, expected):
     generator = DiffractionGenerator(300, shape_factor_model=model)
     assert generator.shape_factor_model == expected
@@ -156,26 +157,30 @@ class TestDiffractionCalculator:
         assert len(diffraction.indices) == len(diffraction.coordinates)
         assert len(diffraction.coordinates) == len(diffraction.intensities)
 
-    def test_precession_simple(self, diffraction_calculator_precession_simple,
-            local_structure):
+    def test_precession_simple(
+        self, diffraction_calculator_precession_simple, local_structure
+    ):
         diffraction = diffraction_calculator_precession_simple.calculate_ed_data(
-            local_structure, reciprocal_radius=5.0,
+            local_structure,
+            reciprocal_radius=5.0,
         )
         assert len(diffraction.indices) == len(diffraction.coordinates)
         assert len(diffraction.coordinates) == len(diffraction.intensities)
 
-    def test_precession_full(self, diffraction_calculator_precession_full,
-            local_structure):
+    def test_precession_full(
+        self, diffraction_calculator_precession_full, local_structure
+    ):
         diffraction = diffraction_calculator_precession_full.calculate_ed_data(
-            local_structure, reciprocal_radius=5.0,
+            local_structure,
+            reciprocal_radius=5.0,
         )
         assert len(diffraction.indices) == len(diffraction.coordinates)
         assert len(diffraction.coordinates) == len(diffraction.intensities)
-        
-    def test_custom_shape_func(self, diffraction_calculator_custom,
-            local_structure):
+
+    def test_custom_shape_func(self, diffraction_calculator_custom, local_structure):
         diffraction = diffraction_calculator_custom.calculate_ed_data(
-            local_structure, reciprocal_radius=5.0,
+            local_structure,
+            reciprocal_radius=5.0,
         )
         assert len(diffraction.indices) == len(diffraction.coordinates)
         assert len(diffraction.coordinates) == len(diffraction.intensities)
@@ -211,9 +216,7 @@ class TestDiffractionCalculator:
         assert np.all(smaller)
 
     def test_shape_factor_strings(self, diffraction_calculator, local_structure):
-        _ = diffraction_calculator.calculate_ed_data(
-            local_structure, 2
-        )
+        _ = diffraction_calculator.calculate_ed_data(local_structure, 2)
 
     def test_shape_factor_custom(self, diffraction_calculator, local_structure):
 

--- a/diffsims/tests/test_generators/test_diffraction_generator.py
+++ b/diffsims/tests/test_generators/test_diffraction_generator.py
@@ -23,10 +23,14 @@ from diffsims.sims.diffraction_simulation import ProfileSimulation
 from diffsims.generators.diffraction_generator import (
     DiffractionGenerator,
     AtomicDiffractionGenerator,
+    _z_sphere_precession,
+    _shape_factor_precession,
+    _average_excitation_error_precession,
 )
 import diffpy.structure
-from diffsims.utils.shape_factor_models import linear, binary, sinc
-
+from diffsims.utils.shape_factor_models import (linear, binary, sinc, sin2c,
+                                                atanc, lorentzian, 
+                                                lorentzian_precession)
 
 @pytest.fixture(params=[(300)])
 def diffraction_calculator(request):
@@ -82,10 +86,45 @@ def probe(x, out=None, scale=None):
         return v + 0 * x[2].reshape(1, 1, -1)
 
 
+@pytest.mark.parametrize("parameters, expected",
+                         [([0, 1, 0.001, 0.5], -0.00822681491001731),
+                          ([0, np.array([1, 2, 20]), 0.001, 0.5],
+                            np.array([-0.00822681, -0.01545354, 0.02547058])),
+                          ([180, 1, 0.001, 0.5], 0.00922693)])
+def test_z_sphere_precession(parameters, expected):
+    result = _z_sphere_precession(*parameters)
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize("model", [linear, atanc, sin2c, lorentzian])
+def test_shape_factor_precession(model):
+    z = np.array([-0.1, 0.1])
+    r = np.array([1, 5])
+    _ = _shape_factor_precession(z, r, 0.001, 0.5, model, 0.1)
+
+
+def test_average_excitation_error_precession():
+    z = np.array([-0.1, 0.1])
+    r = np.array([1, 5])
+    _ = _average_excitation_error_precession(z, r, 0.001, 0.5)
+
+
+@pytest.mark.parametrize("model, expected",
+                         [("linear", linear),
+                          ("lorentzian", lorentzian),
+                          (binary, binary)],)
+def test_diffraction_generator_init(model, expected):
+    generator = DiffractionGenerator(300, shape_factor_model=model)
+    assert generator.shape_factor_model == expected
+
+
 class TestDiffractionCalculator:
     def test_init(self, diffraction_calculator: DiffractionGenerator):
-        assert diffraction_calculator.debye_waller_factors == {}
-        _ = DiffractionGenerator(300, 2)
+        assert diffraction_calculator.scattering_params == "lobato"
+        assert diffraction_calculator.precession_angle == 0
+        assert diffraction_calculator.shape_factor_model == linear
+        assert diffraction_calculator.approximate_precession == True
+        assert diffraction_calculator.minimum_intensity == 1e-20
 
     def test_matching_results(self, diffraction_calculator, local_structure):
         diffraction = diffraction_calculator.calculate_ed_data(
@@ -124,10 +163,9 @@ class TestDiffractionCalculator:
         )
         assert np.all(smaller)
 
-    @pytest.mark.parametrize("model", [None, linear, binary, sinc])
-    def test_shape_factor_strings(self, diffraction_calculator, local_structure, model):
+    def test_shape_factor_strings(self, diffraction_calculator, local_structure):
         _ = diffraction_calculator.calculate_ed_data(
-            local_structure, 2, shape_factor_model=model
+            local_structure, 2
         )
 
     def test_shape_factor_custom(self, diffraction_calculator, local_structure):
@@ -135,10 +173,10 @@ class TestDiffractionCalculator:
             return (np.sin(t) * excitation_error) / maximum_excitation_error
 
         t1 = diffraction_calculator.calculate_ed_data(
-            local_structure, 2, shape_factor_model=local_excite, t=0.2
+            local_structure, 2, max_excitation_error=0.02
         )
         t2 = diffraction_calculator.calculate_ed_data(
-            local_structure, 2, shape_factor_model=local_excite, t=0.4
+            local_structure, 2, max_excitation_error=0.4
         )
 
         # softly makes sure the two sims are different
@@ -202,6 +240,11 @@ def test_param_check(scattering_param):
 def test_invalid_scattering_params():
     scattering_param = "_empty"
     generator = DiffractionGenerator(300, scattering_params=scattering_param)
+
+
+@pytest.mark.xfail(faises=NotImplementedError)
+def test_invalid_shape_model():
+    generator = DiffractionGenerator(300, shape_factor_model="dracula")
 
 
 @pytest.mark.parametrize("shape", [(10, 20), (20, 10)])

--- a/diffsims/tests/test_generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/test_generators/test_sphere_mesh_generators.py
@@ -86,5 +86,5 @@ def test_icosahedral_grid():
 
 def test_vectors_to_euler():
     grid = _normalize_vectors(np.array([[1, 0, 0], [0, 1, 0], [0, 1, 1], [1, 0, 1],]))
-    ang = np.array([[0, 90, 0], [0, 90, 90], [0, 45, 90], [0, 45, 0],])
+    ang = np.array([[0, 90, 90], [0, 90, 0], [0, 45, 0], [0, 45, 90],])
     assert np.allclose(ang, beam_directions_grid_to_euler(grid))

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -77,7 +77,56 @@ def sinc(excitation_error, max_excitation_error, minima_number=5):
     -------
     intensity : array-like or float
     """
+    fac = np.pi * minima_number / max_excitation_error
+    num = np.sin(fac * excitation_error)
+    denom = fac * excitation_error
+    return np.nan_to_num(
+            np.abs(np.divide(num, denom, out=np.zeros_like(num), where=denom != 0)),
+            nan=1,
+            )
 
-    num = np.sin(np.pi * minima_number * excitation_error / max_excitation_error)
-    denom = excitation_error
-    return np.abs(np.divide(num, denom, out=np.zeros_like(num), where=denom != 0))
+
+def sin2c(excitation_error, max_excitation_error, minima_number=5):
+    """
+    Intensity with sin^2(s)/s^2 profile, after Howie-Whelan rel-rod
+
+    Parameters
+    ----------
+    excitation_error : array-like or float
+        The distance (reciprocal) from a reflection to the Ewald sphere
+
+    max_excitation_error : float
+        The distance at which a reflection becomes extinct
+
+    minima_number : int
+        The minima_number'th minima lies at max_excitation_error from 0
+
+    Returns
+    -------
+    intensity : array-like or float
+    """
+    return sinc(excitation_error, max_excitation_error, minima_number)**2
+
+
+def atanc(excitation_error, max_excitation_error):
+    """
+    Intensity with arctan(s)/s profile that closely follows sin(s)/s but
+    is smooth for s!=0.
+
+    Parameters
+    ----------
+    excitation_error : array-like or float
+        The distance (reciprocal) from a reflection to the Ewald sphere
+
+    max_excitation_error : float
+        The distance at which a reflection becomes extinct
+
+    Returns
+    -------
+    intensity : array-like or float
+    """
+    fac = np.pi * 5 / np.abs(max_excitation_error)
+    return np.nan_to_num(
+            np.arctan(fac*excitation_error)/(fac*excitation_error),
+            nan=1,
+            )

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -108,7 +108,7 @@ def sin2c(excitation_error, max_excitation_error, minima_number=5):
     return sinc(excitation_error, max_excitation_error, minima_number)**2
 
 
-def atanc(excitation_error, max_excitation_error):
+def atanc(excitation_error, max_excitation_error, minima_number=5):
     """
     Intensity with arctan(s)/s profile that closely follows sin(s)/s but
     is smooth for s!=0.
@@ -121,11 +121,15 @@ def atanc(excitation_error, max_excitation_error):
     max_excitation_error : float
         The distance at which a reflection becomes extinct
 
+    minima_number : int
+        The minima_number'th minima in the corresponding sinx/x lies at
+        max_excitation_error from 0
+
     Returns
     -------
     intensity : array-like or float
     """
-    fac = np.pi * 5 / np.abs(max_excitation_error)
+    fac = np.pi * minima_number / np.abs(max_excitation_error)
     return np.nan_to_num(
             np.arctan(fac*excitation_error)/(fac*excitation_error),
             nan=1,
@@ -150,8 +154,8 @@ def lorentzian(excitation_error, max_excitation_error):
     intensity_factor : array-like or float
         Vector representing the rel-rod factor for each reflection
 
-    Notes
-    -----
+    References
+    ----------
     [1] L. Palatinus, P. Brázda, M. Jelínek, J. Hrdá, G. Steciuk, M. Klementová, Specifics of the data processing of precession electron diffraction tomography data and their implementation in the program PETS2.0, Acta Crystallogr. Sect. B Struct. Sci. Cryst. Eng. Mater. 75 (2019) 512–522. doi:10.1107/S2052520619007534.
     """
     # in the paper, sigma = pi*thickness.
@@ -187,8 +191,8 @@ def lorentzian_precession(excitation_error, max_excitation_error,
     intensity_factor : array-like or float
         Vector representing the rel-rod factor for each reflection
 
-    Notes
-    -----
+    References
+    ----------
     [1] L. Palatinus, P. Brázda, M. Jelínek, J. Hrdá, G. Steciuk, M. Klementová, Specifics of the data processing of precession electron diffraction tomography data and their implementation in the program PETS2.0, Acta Crystallogr. Sect. B Struct. Sci. Cryst. Eng. Mater. 75 (2019) 512–522. doi:10.1107/S2052520619007534.
     """
     sigma = np.pi/max_excitation_error

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -81,9 +81,9 @@ def sinc(excitation_error, max_excitation_error, minima_number=5):
     num = np.sin(fac * excitation_error)
     denom = fac * excitation_error
     return np.nan_to_num(
-            np.abs(np.divide(num, denom, out=np.zeros_like(num), where=denom != 0)),
-            nan=1,
-            )
+        np.abs(np.divide(num, denom, out=np.zeros_like(num), where=denom != 0)),
+        nan=1,
+    )
 
 
 def sin2c(excitation_error, max_excitation_error, minima_number=5):
@@ -105,7 +105,7 @@ def sin2c(excitation_error, max_excitation_error, minima_number=5):
     -------
     intensity : array-like or float
     """
-    return sinc(excitation_error, max_excitation_error, minima_number)**2
+    return sinc(excitation_error, max_excitation_error, minima_number) ** 2
 
 
 def atanc(excitation_error, max_excitation_error, minima_number=5):
@@ -131,15 +131,15 @@ def atanc(excitation_error, max_excitation_error, minima_number=5):
     """
     fac = np.pi * minima_number / np.abs(max_excitation_error)
     return np.nan_to_num(
-            np.arctan(fac*excitation_error)/(fac*excitation_error),
-            nan=1,
-            )
+        np.arctan(fac * excitation_error) / (fac * excitation_error),
+        nan=1,
+    )
 
 
 def lorentzian(excitation_error, max_excitation_error):
     """
     Lorentzian intensity profile that should approximate
-    the two-beam rocking curve. After [1].
+    the two-beam rocking curve. This is equation (6) in reference [1].
 
     Parameters
     ----------
@@ -160,16 +160,18 @@ def lorentzian(excitation_error, max_excitation_error):
     """
     # in the paper, sigma = pi*thickness.
     # We assume thickness = 1/max_exitation_error
-    sigma = np.pi/max_excitation_error
-    fac = sigma/(np.pi*(sigma**2*excitation_error**2+1))
+    sigma = np.pi / max_excitation_error
+    fac = sigma / (np.pi * (sigma ** 2 * excitation_error ** 2 + 1))
     return fac
 
 
-def lorentzian_precession(excitation_error, max_excitation_error,
-                          r_spot, precession_angle):
+def lorentzian_precession(
+    excitation_error, max_excitation_error, r_spot, precession_angle
+):
     """
     Intensity profile factor for a precessed beam assuming a Lorentzian
-    intensity profile for the un-precessed beam. After [1].
+    intensity profile for the un-precessed beam. This is equation (10) in
+    reference [1].
 
     Parameters
     ----------
@@ -195,8 +197,8 @@ def lorentzian_precession(excitation_error, max_excitation_error,
     ----------
     [1] L. Palatinus, P. Brázda, M. Jelínek, J. Hrdá, G. Steciuk, M. Klementová, Specifics of the data processing of precession electron diffraction tomography data and their implementation in the program PETS2.0, Acta Crystallogr. Sect. B Struct. Sci. Cryst. Eng. Mater. 75 (2019) 512–522. doi:10.1107/S2052520619007534.
     """
-    sigma = np.pi/max_excitation_error
-    u = sigma**2*(r_spot**2*precession_angle**2 - excitation_error**2)+1
-    z = np.sqrt(u**2 + 4*sigma**2 + excitation_error**2)
-    fac = (sigma/np.pi)*np.sqrt(2*(u+z)/z**2)
+    sigma = np.pi / max_excitation_error
+    u = sigma ** 2 * (r_spot ** 2 * precession_angle ** 2 - excitation_error ** 2) + 1
+    z = np.sqrt(u ** 2 + 4 * sigma ** 2 + excitation_error ** 2)
+    fac = (sigma / np.pi) * np.sqrt(2 * (u + z) / z ** 2)
     return fac

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -55,7 +55,7 @@ def linear(excitation_error, max_excitation_error):
     intensities : array-like or float
     """
 
-    return 1 - excitation_error / max_excitation_error
+    return 1 - np.abs(excitation_error) / max_excitation_error
 
 
 def sinc(excitation_error, max_excitation_error, minima_number=5):
@@ -130,3 +130,69 @@ def atanc(excitation_error, max_excitation_error):
             np.arctan(fac*excitation_error)/(fac*excitation_error),
             nan=1,
             )
+
+
+def lorentzian(excitation_error, max_excitation_error):
+    """
+    Lorentzian intensity profile that should approximate
+    the two-beam rocking curve. After [1].
+
+    Parameters
+    ----------
+    excitation_error : array-like or float
+        The distance (reciprocal) from a reflection to the Ewald sphere
+
+    max_excitation_error : float
+        The distance at which a reflection becomes extinct
+
+    Returns
+    -------
+    intensity_factor : array-like or float
+        Vector representing the rel-rod factor for each reflection
+
+    Notes
+    -----
+    [1] L. Palatinus, P. Brázda, M. Jelínek, J. Hrdá, G. Steciuk, M. Klementová, Specifics of the data processing of precession electron diffraction tomography data and their implementation in the program PETS2.0, Acta Crystallogr. Sect. B Struct. Sci. Cryst. Eng. Mater. 75 (2019) 512–522. doi:10.1107/S2052520619007534.
+    """
+    # in the paper, sigma = pi*thickness.
+    # We assume thickness = 1/max_exitation_error
+    sigma = np.pi/max_excitation_error
+    fac = sigma/(np.pi*(sigma**2*excitation_error**2+1))
+    return fac
+
+
+def lorentzian_precession(excitation_error, max_excitation_error,
+                          r_spot, precession_angle):
+    """
+    Intensity profile factor for a precessed beam assuming a Lorentzian
+    intensity profile for the un-precessed beam. After [1].
+
+    Parameters
+    ----------
+    excitation_error : array-like or float
+        The distance (reciprocal) from a reflection to the Ewald sphere
+
+    max_excitation_error : float
+        The distance at which a reflection becomes extinct
+
+    r_spot : array-like or float
+        The distance (reciprocal) from each reflection to the origin
+
+    precession_angle : float
+        The beam precession angle in degrees; the angle the beam makes
+        with the optical axis.
+
+    Returns
+    -------
+    intensity_factor : array-like or float
+        Vector representing the rel-rod factor for each reflection
+
+    Notes
+    -----
+    [1] L. Palatinus, P. Brázda, M. Jelínek, J. Hrdá, G. Steciuk, M. Klementová, Specifics of the data processing of precession electron diffraction tomography data and their implementation in the program PETS2.0, Acta Crystallogr. Sect. B Struct. Sci. Cryst. Eng. Mater. 75 (2019) 512–522. doi:10.1107/S2052520619007534.
+    """
+    sigma = np.pi/max_excitation_error
+    u = sigma**2*(r_spot**2*precession_angle**2 - excitation_error**2)+1
+    z = np.sqrt(u**2 + 4*sigma**2 + excitation_error**2)
+    fac = (sigma/np.pi)*np.sqrt(2*(u+z)/z**2)
+    return fac


### PR DESCRIPTION
What I'm working on here is very premature, opening this PR to get some opinions/feedback and to give you a preview of the code. Apologies for wall of text.

**What does this PR do? Please describe and/or link to an open issue.**
- I fixed a small bug in the `beam_directions_grid_to_euler` function.
- I added the possibility to include the effect of beam precession in the diffraction patterns
- I added/modified some shape factor models
- I modified the way diffraction libraries are generated

**More details**
In the context of my issue #124 and the other discussions we've had elsewhere, I've started looking into the entire chain of operations I would need for template matching with Pyxem. It seems @pc494 you are also kind of working on something in this direction judging by https://github.com/pyxem/pyxem/issues/656?

The things I need for this are:
- a good orientation grid generator (solved in #130)
- simulation of those orientations (currently looking at this point)
- a modified indexer that calculates in-plane rotation, likely via polar transform
- a way to visualize and plot the results; especially quality maps are of interest. I've thrown together a quick stereographic plot functionality for orix but it's too crappy for a PR

The simulated diffraction patterns generated with diffsims looked very odd for my material, in some cases only one diffraction spot was in the pattern. So I looked into:
- the relrod functions in `shape_factor_models`
- the way spot patterns are generated and the available kwargs in `DiffractionGenerator.calculate_ed_data`

With regards to the shape factor function, I saw the default shape is linear. I looked into W&C and at least for a 2-beam case, Howie-Whelan predicts a `(sin(x)/x)^2` - like function, but the exact shape depends also on the extinction distance and thickness. I messed around a bit with the shape factor functions, which you can see here:

![afbeelding](https://user-images.githubusercontent.com/25320842/99184357-80f81980-2742-11eb-9145-ee40bc6d8e0b.png)

`sinc` was a function that was already there, and seems to follow Howie-Whelan quite well. I also tried `sinc^2` but this tapers off the tails too strongly. To get a smooth function that approximately follows the shape of the Howie-Whelan rel-rod I also implemented an `arctan(x)/x` function. I changed all the functions so that the maximum at s=0 hits 1. I figured it doesn't hurt to have a couple more shape factor functions.

To the second point, I felt like the options available for generating a diffraction library "the official way" are a bit lacking:
```
diff_gen = DiffractionGenerator(accelerating_voltage=200, debye_waller_factors)
lib_gen = DiffractionLibraryGenerator(diff_gen)
diff_lib = lib_gen.get_diffraction_library(library_austenite,
                                           calibration=diffraction_calibration,
                                           reciprocal_radius=reciprocal_radius,
                                           half_shape=(half_size, half_size),
                                           with_direct_beam=False)
```
Many of the options in `calculate_ed_data` don't seem to be available this way. I saw that one used to be able to set `max_excitation_error` in `DiffractionGenerator.__init__` but no longer, what is the reason for this?

Personally, I would like to have full control over the way the patterns are simulated. So I'm inclined to change everything either in the init of `DiffractionGenerator` or in the `get_diffraction_library` function. 

In the process of looking into these diffraction patterns, I added the option to include the effect of beam precession. To calculate this I only use geometry; I don't make any additional assumptions. The Ewald sphere is precessed through the rel rods and the shape factor of each spot is calculated by averaging the shape factor function via integration. The difference is minor but there is some:
![afbeelding](https://user-images.githubusercontent.com/25320842/99186592-aa6c7180-2751-11eb-8289-4e11634f0153.png)
Especially further away reflections become a bit brighter with precession. The influence depends on the chosen shape factor model - above I use the `atanc` function. Below is with `linear`
![afbeelding](https://user-images.githubusercontent.com/25320842/99186717-85c4c980-2752-11eb-99d3-1d9067b62afe.png)
I think the math on the precession is sound but a second pair of eyes might verify this. Of course with this implementation, precession is much more expensive, since I do an integration for each relevant diffraction spot.

**Are there any known issues? Do you need help?**
The main thing I'm unsure about is which arguments should go where, and why certain arguments were removed. 

**Work in progress?**
- [x] I haven't included any testing yet
- [x] My alteration of the existing functions could break existing tests

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
