### PR TITLE
added random sphere mesh generator

### DIFF
--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -31,6 +31,7 @@ from diffsims.generators.sphere_mesh_generators import (
     get_uv_sphere_mesh_vertices,
     get_cube_mesh_vertices,
     get_icosahedral_mesh_vertices,
+    get_random_sphere_vertices,
     beam_directions_grid_to_euler,
 )
 
@@ -186,8 +187,8 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_c
     mesh : str
         Type of meshing of the sphere that defines how the grid is
         created. Options are: uv_sphere, normalized_cube,
-        spherified_cube_corner (default), spherified_cube_edge, and
-        icosahedral.
+        spherified_cube_corner (default), spherified_cube_edge,
+        icosahedral, random.
 
     Returns
     -------
@@ -216,13 +217,14 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_c
             points_in_cartesians = get_cube_mesh_vertices(
                 resolution, grid_type="spherified_edge"
             )
-
+    elif mesh == "random":
+        points_in_cartesians = get_random_sphere_vertices(resolution)
     else:
         raise NotImplementedError(
             f"The mesh {mesh} is not recognized. "
             f"Please use: uv_sphere, normalized_cube, "
             f"spherified_cube_edge, "
-            f"spherified_cube_corner, icosahedral"
+            f"spherified_cube_corner, icosahedral, random"
         )
 
     if crystal_system == "triclinic":

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -442,15 +442,18 @@ def get_icosahedral_mesh_vertices(resolution):
     return vertices
 
 
-def get_random_sphere_vertices(resolution):
+def get_random_sphere_vertices(resolution,seed=None):
     """
     Create a mesh that randomly samples the surface of a sphere
 
     Parameters
     ----------
-    resolution: float
+    resolution : float
         The expected mean angle between nearest neighbor
         grid points in degrees.
+    seed : int, optional
+        passed to np.random.default_rng(), defaults to None which 
+        will give a "new" random result each time
 
     Returns
     -------
@@ -463,7 +466,12 @@ def get_random_sphere_vertices(resolution):
     """
     # convert resolution in degrees to number of points
     number = int(1/(4*np.pi)*(360/resolution)**2)
-    xyz = np.random.normal(size=(number, 3))
+    if seed is not None:
+        rng =np.random.default_rng(seed=seed)
+    else:
+        rng = np.random.default_rng()
+        
+    xyz = rng.normal(size=(number, 3))
     xyz = (xyz.T/np.linalg.norm(xyz, axis=1)).T
     return xyz
 

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -442,6 +442,32 @@ def get_icosahedral_mesh_vertices(resolution):
     return vertices
 
 
+def get_random_sphere_vertices(resolution):
+    """
+    Create a mesh that randomly samples the surface of a sphere
+
+    Parameters
+    ----------
+    resolution: float
+        The expected mean angle between nearest neighbor
+        grid points in degrees.
+
+    Returns
+    -------
+    points_in_cartesian : numpy.ndarray (N,3)
+        Rows are x, y, z where z is the 001 pole direction
+
+    References
+    ----------
+    https://mathworld.wolfram.com/SpherePointPicking.html
+    """
+    # convert resolution in degrees to number of points
+    number = int(1/(4*np.pi)*(360/resolution)**2)
+    xyz = np.random.normal(size=(number, 3))
+    xyz = (xyz.T/np.linalg.norm(xyz, axis=1)).T
+    return xyz
+
+
 def beam_directions_grid_to_euler(vectors):
     """
     Convert list of vectors representing zones to a list of Euler angles

--- a/diffsims/tests/test_generators/test_rotation_list_generator.py
+++ b/diffsims/tests/test_generators/test_rotation_list_generator.py
@@ -57,6 +57,7 @@ def test_get_grid_around_beam_direction():
         "spherified_cube_edge",
         "spherified_cube_corner",
         "icosahedral",
+        "random",
     ],
 )
 @pytest.mark.parametrize(
@@ -73,6 +74,7 @@ def test_get_grid_around_beam_direction():
 )
 def test_get_beam_directions_grid(crystal_system, mesh):
     grid = get_beam_directions_grid(crystal_system, 5, mesh=mesh)
+
 
 @pytest.mark.xfail()
 def test_invalid_mesh_beam_directions():

--- a/diffsims/tests/test_generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/test_generators/test_sphere_mesh_generators.py
@@ -22,12 +22,19 @@ from diffsims.generators.sphere_mesh_generators import (
     get_uv_sphere_mesh_vertices,
     get_cube_mesh_vertices,
     get_icosahedral_mesh_vertices,
+    get_random_sphere_vertices,
     beam_directions_grid_to_euler,
     _normalize_vectors,
     _get_first_nearest_neighbors,
     _get_angles_between_nn_gridpoints,
     _get_max_grid_angle,
 )
+
+
+def test_random_sphere_mesh():
+    grid = get_random_sphere_vertices(1)
+    assert grid.shape[0] == 10313
+    assert grid.shape[1] == 3
 
 
 def test_get_uv_sphere_mesh_vertices():


### PR DESCRIPTION
---
name: Adds a generator for a random beam_directions grid

---

**Release Notes**
> Randomly sample the unit sphere surface to generate a random mesh. You can specify the average angular distance between points like in the other meshes, which gets translated into number of points to sample.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
