### PR TITLE
Make ReciprocalLatticePoint handle having only one point/vector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ src/
 .vscode/
 /.project
 /.pydevproject
+*.code-workspace
 
 #Ds store stuff
 .DS_store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Python 3.6 testing
+
+### Fixed
+- ReciprocalLatticePoint handles having only one point/vector

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -18,6 +18,7 @@
 
 from collections import defaultdict
 from itertools import product
+import warnings
 
 import numpy as np
 from orix.vector import Vector3d
@@ -51,8 +52,9 @@ class ReciprocalLatticePoint:
         hkl : orix.vector.Vector3d, np.ndarray, list, or tuple
             Miller indices.
         """
-        self._hkl = Vector3d(hkl)
         self.phase = phase
+        self._raise_if_no_point_group()
+        self._hkl = Vector3d(hkl)
         self._structure_factor = [None] * self.size
         self._theta = [None] * self.size
 
@@ -81,24 +83,19 @@ class ReciprocalLatticePoint:
         return Vector3d(self._hkl.data.astype(int))
 
     @property
-    def _hkldata(self):
-        """Return :class:`np.ndarray` without 1-dimensions."""
-        return np.squeeze(self.hkl.data)
-
-    @property
     def h(self):
         """Return :class:`np.ndarray` of Miller index h."""
-        return self._hkldata[..., 0]
+        return self.hkl.data[..., 0]
 
     @property
     def k(self):
         """Return :class:`np.ndarray` of Miller index k."""
-        return self._hkldata[..., 1]
+        return self.hkl.data[..., 1]
 
     @property
     def l(self):
         """Return :class:`np.ndarray` of Miller index l."""
-        return self._hkldata[..., 2]
+        return self.hkl.data[..., 2]
 
     @property
     def size(self):
@@ -108,7 +105,7 @@ class ReciprocalLatticePoint:
     @property
     def shape(self):
         """Return `tuple`."""
-        return self._hkldata.shape
+        return self.hkl.data.shape
 
     @property
     def multiplicity(self):
@@ -120,7 +117,7 @@ class ReciprocalLatticePoint:
         """Return :class:`np.ndarray` of reciprocal lattice point
         spacings.
         """
-        return self.phase.structure.lattice.rnorm(self._hkldata)
+        return self.phase.structure.lattice.rnorm(self.hkl.data)
 
     @property
     def dspacing(self):
@@ -144,6 +141,8 @@ class ReciprocalLatticePoint:
         """Return whether planes diffract according to structure_factor
         selection rules assuming kinematical scattering theory.
         """
+        self._raise_if_no_space_group()
+
         # Translational symmetry
         centering = self.phase.space_group.short_name[0]
 
@@ -156,10 +155,10 @@ class ReciprocalLatticePoint:
             else:  # Any hkl
                 return np.ones(self.size, dtype=bool)
         elif centering == "F":  # Face-centred, hkl all odd/even
-            selection = np.sum(np.mod(self._hkldata, 2), axis=1)
+            selection = np.sum(np.mod(self.hkl.data, 2), axis=1)
             return np.array([i not in [1, 2] for i in selection], dtype=bool)
         elif centering == "I":  # Body-centred, h + k + l = 2n (even)
-            return np.mod(np.sum(self._hkldata, axis=1), 2) == 0
+            return np.mod(np.sum(self.hkl.data, axis=1), 2) == 0
         elif centering == "A":  # Centred on A faces only
             return np.mod(self.k + self.l, 2) == 0
         elif centering == "B":  # Centred on B faces only
@@ -224,7 +223,7 @@ class ReciprocalLatticePoint:
         ReciprocalLatticePoint
         """
         if use_symmetry:
-            all_hkl = self._hkldata
+            all_hkl = self.hkl.data
             # Remove [0, 0, 0] points
             all_hkl = all_hkl[~np.all(np.isclose(all_hkl, 0), axis=1)]
 
@@ -328,9 +327,7 @@ class ReciprocalLatticePoint:
 
         # TODO: Find a better way to call different methods in the loop
         structure_factors = np.zeros(self.size)
-        for i, (hkl, s) in enumerate(
-            zip(np.atleast_2d(self._hkldata), np.atleast_1d(self.scattering_parameter))
-        ):
+        for i, (hkl, s) in enumerate(zip(self.hkl.data, self.scattering_parameter)):
             if method == "kinematical":
                 structure_factors[i] = get_kinematical_structure_factor(
                     phase=self.phase,
@@ -359,6 +356,20 @@ class ReciprocalLatticePoint:
         """
         wavelength = get_refraction_corrected_wavelength(self.phase, voltage)
         self._theta = np.arcsin(0.5 * wavelength * self.gspacing)
+
+    def _raise_if_no_point_group(self):
+        """Raise ValueError if the phase attribute has no point group
+        set.
+        """
+        if self.phase.point_group is None:
+            raise ValueError(f"The phase {self.phase} must have a point group set")
+
+    def _raise_if_no_space_group(self):
+        """Raise ValueError if the phase attribute has no space group
+        set.
+        """
+        if self.phase.space_group is None:
+            raise ValueError(f"The phase {self.phase} must have a space group set")
 
 
 def get_highest_hkl(lattice, min_dspacing=0.5):

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -18,7 +18,6 @@
 
 from collections import defaultdict
 from itertools import product
-import warnings
 
 import numpy as np
 from orix.vector import Vector3d

--- a/diffsims/tests/test_crystallography/test_reciprocal_lattice_point.py
+++ b/diffsims/tests/test_crystallography/test_reciprocal_lattice_point.py
@@ -288,7 +288,6 @@ class TestReciprocalLatticePoint:
 
     def test_one_point(self, ferrite_phase):
         rlp = ReciprocalLatticePoint(phase=ferrite_phase, hkl=[1, 1, 0])
-        repr(rlp)
 
         assert rlp.size == 1
         assert np.allclose(rlp.allowed, True)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

---
name: Make ReciprocalLatticePoint handle having only one point/vector
about: Fix #125 

---

**Release Notes**
> bugfix
ReciprocalLatticePoint handles having only one point/vector

**What does this PR do? Please describe and/or link to an open issue.**
* Close #125.
* Make `ReciprocalLatticePoint` handle having only one point/vector by not using the `_hkldata` attribute. The introduction of that attribute was not well thought through, so I removed it. A test is added to ensure that `ReciprocalLatticePoint.allowed` works with only one vector.
* Add private methods to raise a `ValueError` if the `ReciprocalLatticePoint` requires a point or space group, but it's set to `None`. And use these in `init()` and the `allowed` property, respectively. Anticipating that this will be used more, therefore private methods.

**Are there any known issues? Do you need help?**
kikuchipy uses the `ReciprocalLatticePoint._hkldata`, so we have to change this use to `.hkl.data`!

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
