### PR TITLE
Get {hkl} families from a list of (hkl) in the ReciprocalLatticePoint class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - `ReciprocalLatticePoint.unique()` takes a `reduce` boolean parameter to make
-  e.g. (hkl) [2, 0, 0] equivalent to [1, 0, 0]
+  e.g. (2, 0, 0) equivalent to (1, 0, 0)
 - `get_grid_beam_directions`, now works based off of meshes
 - the arguments in the `DiffractionGenerator` constructor and the `DiffractionLibraryGenerator.get_diffraction_library` function have been shuffled so that the former captures arguments related to "the instrument/physics" while the latter captures arguments relevant to "the sample/material".
 - CI is now provided by github actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- `ReciprocalLatticePoint.unique()` takes a `reduce` boolean parameter to make
+  e.g. (hkl) [2, 0, 0] equivalent to [1, 0, 0]
 - `get_grid_beam_directions`, now works based off of meshes
 - the arguments in the `DiffractionGenerator` constructor and the `DiffractionLibraryGenerator.get_diffraction_library` function have been shuffled so that the former captures arguments related to "the instrument/physics" while the latter captures arguments relevant to "the sample/material".
 - CI is now provided by github actions
 
 ### Added
+- `ReciprocalLatticePoint` read-only properties `families`, `n_families` and `family`
 - API reference documentation via Read The Docs: https://diffsims.rtfd.io
 - New module: `sphere_mesh_generators`
 - beam precession is now supported in simulating electron diffraction patterns
@@ -21,4 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python 3.6 testing
 
 ### Fixed
-- ReciprocalLatticePoint handles having only one point/vector
+- `ReciprocalLatticePoint` handles having only one point/vector

--- a/diffsims/crystallography/__init__.py
+++ b/diffsims/crystallography/__init__.py
@@ -25,6 +25,7 @@ from diffsims.crystallography.reciprocal_lattice_point import (
     get_equivalent_hkl,
     get_highest_hkl,
     get_hkl,
+    get_hkl_family,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "get_equivalent_hkl",
     "get_highest_hkl",
     "get_hkl",
+    "get_hkl_family",
 ]

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -89,6 +89,7 @@ class ReciprocalLatticePoint:
         """Return :class:`numpy.ndarray` without 1-dimensions."""
         return np.squeeze(self.hkl.data)
 
+    @property
     def h(self):
         """Return :class:`np.ndarray` of Miller index h."""
         return self.hkl.data[..., 0]

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -48,7 +48,8 @@ class ReciprocalLatticePoint:
         phase : orix.crystal_map.phase_list.Phase
             A phase container with a crystal structure and a space and
             point group describing the allowed symmetry operations.
-        hkl : orix.vector.Vector3d, np.ndarray, list, or tuple
+        hkl : orix.vector.vector3d.Vector3d, numpy.ndarray, list, or\
+                tuple
             Miller indices.
         """
         self._hkl = Vector3d(hkl)
@@ -77,27 +78,29 @@ class ReciprocalLatticePoint:
 
     @property
     def hkl(self):
-        """Return :class:`~orix.vector.Vector3d` of Miller indices."""
+        """Return :class:`~orix.vector.vector3.Vector3d` of Miller
+        indices.
+        """
         return Vector3d(self._hkl.data.astype(int))
 
     @property
     def _hkldata(self):
-        """Return :class:`np.ndarray` without 1-dimensions."""
+        """Return :class:`numpy.ndarray` without 1-dimensions."""
         return np.squeeze(self.hkl.data)
 
     @property
     def h(self):
-        """Return :class:`np.ndarray` of Miller index h."""
+        """Return :class:`numpy.ndarray` of Miller index h."""
         return self._hkldata[..., 0]
 
     @property
     def k(self):
-        """Return :class:`np.ndarray` of Miller index k."""
+        """Return :class:`numpy.ndarray` of Miller index k."""
         return self._hkldata[..., 1]
 
     @property
     def l(self):
-        """Return :class:`np.ndarray` of Miller index l."""
+        """Return :class:`numpy.ndarray` of Miller index l."""
         return self._hkldata[..., 2]
 
     @property
@@ -112,31 +115,31 @@ class ReciprocalLatticePoint:
 
     @property
     def multiplicity(self):
-        """Return either `int` or :class:`np.ndarray` of `int`."""
+        """Return either `int` or :class:`numpy.ndarray` of `int`."""
         return self.symmetrise(antipodal=True, return_multiplicity=True)[1]
 
     @property
     def gspacing(self):
-        """Return :class:`np.ndarray` of reciprocal lattice point
+        """Return :class:`numpy.ndarray` of reciprocal lattice point
         spacings.
         """
         return self.phase.structure.lattice.rnorm(self._hkldata)
 
     @property
     def dspacing(self):
-        """Return :class:`np.ndarray` of direct lattice interplanar
+        """Return :class:`numpy.ndarray` of direct lattice interplanar
         spacings.
         """
         return 1 / self.gspacing
 
     @property
     def scattering_parameter(self):
-        """Return :class:`np.ndarray` of scattering parameters s."""
+        """Return :class:`numpy.ndarray` of scattering parameters s."""
         return 0.5 * self.gspacing
 
     @property
     def structure_factor(self):
-        """Return :class:`np.ndarray` of structure factors F or None."""
+        """Return :class:`numpy.ndarray` of structure factors F or None."""
         return self._structure_factor
 
     @property
@@ -171,8 +174,12 @@ class ReciprocalLatticePoint:
 
     @property
     def theta(self):
-        """Return :class:`np.ndarray` of twice the Bragg angle."""
+        """Return :class:`numpy.ndarray` of twice the Bragg angle."""
         return self._theta
+
+    @property
+    def families(self):
+        """Return symmetrically unique Miller indices."""
 
     @classmethod
     def from_min_dspacing(cls, phase, min_dspacing=0.5):
@@ -204,7 +211,7 @@ class ReciprocalLatticePoint:
         phase : orix.crystal_map.phase_list.Phase
             A phase container with a crystal structure and a space and
             point group describing the allowed symmetry operations.
-        highest_hkl : np.ndarray, list, or tuple of int
+        highest_hkl : numpy.ndarray, list, or tuple of int
             Highest Miller indices to consider (including).
         """
         hkl = get_hkl(highest_hkl=highest_hkl)
@@ -272,7 +279,7 @@ class ReciprocalLatticePoint:
         ReciprocalLatticePoint
             Planes with Miller indices symmetrically equivalent to the
             original planes.
-        multiplicity : np.ndarray
+        multiplicity : numpy.ndarray
             Multiplicity of the original Miller indices. Only returned if
             `return_multiplicity` is True.
 
@@ -375,7 +382,7 @@ def get_highest_hkl(lattice, min_dspacing=0.5):
 
     Returns
     -------
-    highest_hkl : np.ndarray
+    highest_hkl : numpy.ndarray
         Highest Miller indices.
     """
     highest_hkl = np.ones(3, dtype=int)
@@ -394,12 +401,13 @@ def get_hkl(highest_hkl):
 
     Parameters
     ----------
-    highest_hkl : orix.vector.Vector3d, np.ndarray, list, or tuple of int
+    highest_hkl : orix.vector.vector3d.Vector3d, numpy.ndarray, list,\
+            or tuple of int
         Highest Miller indices to consider.
 
     Returns
     -------
-    hkl : np.ndarray
+    hkl : numpy.ndarray
         An array of Miller indices.
     """
     index_ranges = [np.arange(-i, i + 1) for i in highest_hkl]
@@ -411,7 +419,8 @@ def get_equivalent_hkl(hkl, operations, unique=False, return_multiplicity=False)
 
     Parameters
     ----------
-    hkl : orix.vector.Vector3d, np.ndarray, list or tuple of int
+    hkl : orix.vector.vector3.Vector3d, numpy.ndarray, list or tuple of\
+            int
         Miller indices.
     operations : orix.quaternion.symmetry.Symmetry
         Point group describing allowed symmetry operations.
@@ -423,9 +432,9 @@ def get_equivalent_hkl(hkl, operations, unique=False, return_multiplicity=False)
 
     Returns
     -------
-    new_hkl : orix.vector.Vector3d
+    new_hkl : orix.vector.vector3.Vector3d
         The symmetrically equivalent Miller indices.
-    multiplicity : np.ndarray
+    multiplicity : numpy.ndarray
         Number of symmetrically equivalent indices. Only returned if
         `return_multiplicity` is True.
     """
@@ -454,5 +463,43 @@ def get_equivalent_hkl(hkl, operations, unique=False, return_multiplicity=False)
         return new_hkl
 
 
-def _is_equivalent(this_hkl: list, that_hkl: list) -> bool:
-    return sorted(np.abs(this_hkl)) == sorted(np.abs(that_hkl))
+def _is_equivalent(this_hkl, that_hkl, reduce=False):
+    """Determine whether two Miller index 3-tuples are equivalent.
+    Symmetry is not considered.
+
+    Parameters
+    ----------
+    this_hkl : list
+    that_hkl : list
+    reduce : bool, optional
+
+    Returns
+    -------
+    bool
+    """
+    if reduce:
+        this_hkl, _ = _reduce_hkl(this_hkl)
+        that_hkl, _ = _reduce_hkl(that_hkl)
+    return np.allclose(
+        np.sort(np.abs(this_hkl).astype(int)),
+        np.sort(np.abs(that_hkl).astype(int)),
+    )
+
+
+def _reduce_hkl(hkl):
+    """Reduce Miller indices 3-tuples by a greatest common divisor.
+
+    Parameters
+    ----------
+    hkl : list or numpy.ndarray
+
+    Returns
+    -------
+    numpy.ndarray
+    numpy.ndarray
+    """
+    hkl = np.atleast_2d(hkl)
+    divisor = np.gcd.reduce(hkl, axis=1)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        hkl = hkl / divisor[:, np.newaxis]
+    return hkl.astype(int), divisor

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -199,8 +199,8 @@ class DiffractionGenerator(object):
     * A full calculation is much slower and is not recommended for calculating
       a diffraction library for precession diffraction patterns.
     * When using precession and approximate_precession=True, the shape factor
-    model defaults to Lorentzian; shape_factor_model is ignored. Only with
-    approximate_precession=False the custom shape_factor_model is used.
+      model defaults to Lorentzian; shape_factor_model is ignored. Only with
+      approximate_precession=False the custom shape_factor_model is used.
     """
 
     def __init__(

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -442,23 +442,22 @@ def get_icosahedral_mesh_vertices(resolution):
     return vertices
 
 
-def get_random_sphere_vertices(resolution,seed=None):
-    """
-    Create a mesh that randomly samples the surface of a sphere
+def get_random_sphere_vertices(resolution, seed=None):
+    """Create a mesh that randomly samples the surface of a sphere.
 
     Parameters
     ----------
     resolution : float
-        The expected mean angle between nearest neighbor
-        grid points in degrees.
+        The expected mean angle between nearest neighbor grid points in
+        degrees.
     seed : int, optional
-        passed to np.random.default_rng(), defaults to None which 
-        will give a "new" random result each time
+        Passed to np.random.default_rng(), defaults to None which will
+        give a "new" random result each time.
 
     Returns
     -------
-    points_in_cartesian : numpy.ndarray (N,3)
-        Rows are x, y, z where z is the 001 pole direction
+    points_in_cartesian : numpy.ndarray (N, 3)
+        Rows are x, y, z where z is the 001 pole direction.
 
     References
     ----------
@@ -467,7 +466,7 @@ def get_random_sphere_vertices(resolution,seed=None):
     # convert resolution in degrees to number of points
     number = int(1/(4*np.pi)*(360/resolution)**2)
     if seed is not None:
-        rng =np.random.default_rng(seed=seed)
+        rng = np.random.default_rng(seed=seed)
     else:
         rng = np.random.default_rng()
         

--- a/diffsims/tests/test_crystallography/test_reciprocal_lattice_point.py
+++ b/diffsims/tests/test_crystallography/test_reciprocal_lattice_point.py
@@ -284,3 +284,9 @@ class TestReciprocalLatticePoint:
         rlp = ReciprocalLatticePoint(phase=ferrite_phase, hkl=hkl)
         rlp.calculate_theta(voltage=voltage)
         assert np.allclose(rlp.theta, desired_theta)
+
+    def test_families(self, ferrite_phase):
+        pass
+
+    def test_families_indices(self, ferrite_phase):
+        pass

--- a/diffsims/tests/test_generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/test_generators/test_sphere_mesh_generators.py
@@ -18,6 +18,7 @@
 
 import pytest
 import numpy as np
+
 from diffsims.generators.sphere_mesh_generators import (
     get_uv_sphere_mesh_vertices,
     get_cube_mesh_vertices,
@@ -35,6 +36,16 @@ def test_random_sphere_mesh():
     grid = get_random_sphere_vertices(1)
     assert grid.shape[0] == 10313
     assert grid.shape[1] == 3
+
+    res = 10
+    assert np.allclose(
+        get_random_sphere_vertices(resolution=res, seed=1),
+        get_random_sphere_vertices(resolution=res, seed=1),
+    )
+    assert not np.allclose(
+        get_random_sphere_vertices(resolution=res, seed=1),
+        get_random_sphere_vertices(resolution=res, seed=2),
+    )
 
 
 def test_get_uv_sphere_mesh_vertices():

--- a/diffsims/tests/test_utils/test_sim_utils.py
+++ b/diffsims/tests/test_utils/test_sim_utils.py
@@ -65,6 +65,8 @@ def test_get_interaction_constant(accelerating_voltage, interaction_constant):
     np.testing.assert_almost_equal(val, interaction_constant)
 
 
+# TODO: Remove when functionality is replaced by
+#  diffsims.crystallography.get_hkl_family()
 def test_get_unique_families():
     hkls = ((0, 1, 1), (1, 1, 0))
     unique_families = get_unique_families(hkls)

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -73,6 +73,8 @@ def get_interaction_constant(accelerating_voltage):
     return sigma
 
 
+# TODO: Remove when functionality is replaced by
+#  diffsims.crystallography.get_hkl_family()
 def get_unique_families(hkls):
     """Returns unique families of Miller indices, which must be permutations of
     each other.


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

---
name: Get families {hkl} in list of (hkl)
about: Add families attribute to ReciprocalLatticePoint

---

**Release Notes**
> new feature
Add possibility to get families {hkl} from list of (hkl) `ReciprocalLatticePoint`

**What does this PR do? Please describe and/or link to an open issue.**
Close #133 

Add the following `ReciprocalLatticePoint` class attributes:
* `.families`: array of {hkl} families from all (hkl) in the instance
* `.n_families`: number of {hkl} families
* `.family`: index into `families` array for each (hkl)

These new attributes are calculated from the new or updated functions:
* `get_hkl_family()` (new): Return {hkl} families and to which family each (hkl) belongs. Public function, importable from `diffsims.crystallography.get_hkl_family`.
* `_reduce_hkl()` (new): Reduce Miller indices 3-tuples by a greatest common divisor.
* `_is_equivalent()` (updated): Determine whether two sets of Miller indices are equivalent. Symmetry is not considered.

Tests are added for this functionality, but only for the cubic crystal system...

With the addition of `_reduce_hkl()`, a `reduce: bool = False` parameter is added to `ReciprocalLatticePoint.unique()` so that e.g. [[2, 0, 0], [1, 0, 0]] -> [1, 0, 0].

Other additions:
* TODOs to remove `get_unique_families()` and corresponding test.
* Minor docstring intersphinx corrections
* Added test of `seed` parameter in `get_random_sphere_vertices()` -> 100% coverage.

**Example**

```python
>>> from orix.crystal_map import Phase
>>> from diffsims.crystallography import ReciprocalLatticePoint
>>> rlp = ReciprocalLatticePoint(
...     phase=Phase(space_group=225),
...     hkl=[[-1, -1, -1], [1, 0, 0], [1, 1, 1], [0, 0, 1], [2, 0, 0]
... )
>>> rlp
ReciprocalLatticePoint (5,)
Phase: ferrite (m-3m)
[[-1 -1 -1]
 [ 1  0  0]
 [ 1  1  1]
 [ 0  0  1]
 [ 2  0  0]]
>>> rlp.unique()
ReciprocalLatticePoint (3,)
Phase: ferrite (m-3m)
[[-1 -1 -1]
 [ 1  0  0]
 [ 2  0  0]]
>>> rlp.unique(reduce=True)
ReciprocalLatticePoint (2,)
Phase: ferrite (m-3m)
[[-1 -1 -1]
 [ 1  0  0]]
>>> rlp.n_families
2
>>> rlp.families
array([[-1, -1, -1],
       [ 1,  0,  0]])
>>> rlp.family
array([0, 1, 0, 1, 1])
```

**Describe alternatives you've considered**
This functionality is in the [kikuchipy.crystallography module](https://github.com/pyxem/kikuchipy/blob/master/kikuchipy/crystallography/_computations.py#L46), but belongs here.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Merge `master` with #145 into this branch
- [x] Add actual `ReciprocalLatticePoint.families` attribute
- [x] Test it (port [tests from kikuchipy](https://github.com/pyxem/kikuchipy/blob/master/kikuchipy/crystallography/tests/test_crystallographic_computations.py#L144))
- [x] Add changelog entry

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
