### PR TITLE
Patching the detector_functions module (see review of #143)

### DIFF
--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -198,9 +198,11 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
     xdead = rng.uniform(low=0, high=pattern.shape[0], size=n).astype(int)
     ydead = rng.uniform(low=0, high=pattern.shape[1], size=n).astype(int)
 
-    pattern[ydead, xdead] = 0
+    # otherwise pattern will also have 0 elements
+    corrupted = pattern.copy()
+    corrupted[ydead, xdead] = 0
 
-    return pattern
+    return corrupted
 
 
 def add_linear_detector_gain(pattern, gain):

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+np.ndarray# -*- coding: utf-8 -*-
 # Copyright 2017-2020 The diffsims developers
 #
 # This file is part of diffsims.
@@ -37,14 +37,14 @@ def constrain_to_dynamic_range(pattern, detector_max=None):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector after corruption
     detector_max : float
         The maximum allowed value at the detector
 
     Returns
     -------
-    within_range_pattern: np.array
+    within_range_pattern: np.ndarray
         The pattern, with values >=0 and =< detector_max
     """
     pattern[pattern < 0] = 0
@@ -61,14 +61,14 @@ def add_gaussian_point_spread(pattern, sigma):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
     sigma : float
         The standard deviation of the gaussian blur, in pixels
 
     Returns
     -------
-    blurred_pattern : np.array
+    blurred_pattern : np.ndarray
         The blurred pattern (deterministic)
     """
     return ndi.gaussian_filter(pattern, sigma)
@@ -80,14 +80,14 @@ def add_shot_noise(pattern, seed=None):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
     seed : int or None
         seed value for the random number generator
 
     Returns
     -------
-    shotted_pattern : np.array
+    shotted_pattern : np.ndarray
         A single sample of the pattern after accounting for shot noise
 
     Notes
@@ -106,7 +106,7 @@ def add_shot_and_point_spread(pattern, sigma, shot_noise=True, seed=None):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
     sigma : float
         The standard deviation of the gaussian blur, in pixels
@@ -117,7 +117,7 @@ def add_shot_and_point_spread(pattern, sigma, shot_noise=True, seed=None):
 
     Returns
     -------
-    detector_pattern : np.array
+    detector_pattern : np.ndarray
         A single sample of the pattern after accounting for detector properties
 
     See also
@@ -141,7 +141,7 @@ def add_gaussian_noise(pattern, sigma, seed=None):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
     sigma : float
         The (absolute) deviation of the gaussian errors
@@ -165,7 +165,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
     n : int
         The number of dead pixels, defaults to None
@@ -176,7 +176,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
 
     Returns
     -------
-    corrupted_pattern : np.array
+    corrupted_pattern : np.ndarray
         The pattern, with dead pixels included
     """
     # sorting the n/fraction kwargs
@@ -211,13 +211,13 @@ def add_linear_detector_gain(pattern, gain):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
-    gain : float or np.array
+    gain : float or np.ndarray
         Multiplied through the pattern, broadcasting applies
     Returns
     -------
-    corrupted_pattern : np.array
+    corrupted_pattern : np.ndarray
         The pattern, with gain applied
     """
     return np.multiply(pattern, gain)
@@ -229,13 +229,13 @@ def add_detector_offset(pattern, offset):
 
     Parameters
     ----------
-    pattern : np.array
+    pattern : np.ndarray
         The diffraction pattern at the detector
-    offset : float or np.array
+    offset : float or np.ndarray
         Added through the pattern, broadcasting applies
     Returns
     -------
-    corrupted_pattern : np.array
+    corrupted_pattern : np.ndarray
         The pattern, with offset applied, pixels that would have been negative
         are instead 0.
     """

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -21,6 +21,7 @@ import numpy as np
 from numpy.random import default_rng
 from scipy import ndimage as ndi
 
+
 def constrain_to_dynamic_range(pattern, detector_max=None):
     """Force the values within pattern to lie between [0,detector_max]
 

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -1,4 +1,4 @@
-np.ndarray# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # Copyright 2017-2020 The diffsims developers
 #
 # This file is part of diffsims.

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -52,14 +52,14 @@ def add_gaussian_point_spread(pattern, sigma):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
     sigma : float
         The standard deviation of the gaussian blur, in pixels
 
     Returns
     -------
-    blurred_pattern : np.ndarray
+    blurred_pattern : numpy.ndarray
         The blurred pattern (deterministic)
     """
     return ndi.gaussian_filter(pattern, sigma)
@@ -71,14 +71,14 @@ def add_shot_noise(pattern, seed=None):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
     seed : int or None
         seed value for the random number generator
 
     Returns
     -------
-    shotted_pattern : np.ndarray
+    shotted_pattern : numpy.ndarray
         A single sample of the pattern after accounting for shot noise
 
     Notes
@@ -97,7 +97,7 @@ def add_shot_and_point_spread(pattern, sigma, shot_noise=True, seed=None):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
     sigma : float
         The standard deviation of the gaussian blur, in pixels
@@ -108,13 +108,13 @@ def add_shot_and_point_spread(pattern, sigma, shot_noise=True, seed=None):
 
     Returns
     -------
-    detector_pattern : np.ndarray
+    detector_pattern : numpy.ndarray
         A single sample of the pattern after accounting for detector properties
 
     See also
     --------
     add_shot_noise : adds only shot noise
-    add_gaussian_point_spread
+    add_gaussian_point_spread : adds only point spread
     """
 
     # shot noise happens before the detector response (operations won't commute)
@@ -132,7 +132,7 @@ def add_gaussian_noise(pattern, sigma, seed=None):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
     sigma : float
         The (absolute) deviation of the gaussian errors
@@ -156,7 +156,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
     n : int
         The number of dead pixels, defaults to None
@@ -167,7 +167,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
 
     Returns
     -------
-    corrupted_pattern : np.ndarray
+    corrupted_pattern : numpy.ndarray
         The pattern, with dead pixels included
     """
     # sorting the n/fraction kwargs
@@ -201,13 +201,13 @@ def add_linear_detector_gain(pattern, gain):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
-    gain : float or np.ndarray
+    gain : float or numpy.ndarray
         Multiplied through the pattern, broadcasting applies
     Returns
     -------
-    corrupted_pattern : np.ndarray
+    corrupted_pattern : numpy.ndarray
         The pattern, with gain applied
     """
     return np.multiply(pattern, gain)
@@ -219,9 +219,9 @@ def add_detector_offset(pattern, offset):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector
-    offset : float or np.ndarray
+    offset : float or numpy.ndarray
         Added through the pattern, broadcasting applies
     Returns
     -------

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -198,7 +198,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
     xdead = rng.uniform(low=0, high=pattern.shape[0], size=n).astype(int)
     ydead = rng.uniform(low=0, high=pattern.shape[1], size=n).astype(int)
 
-    pattern[xdead, ydead] = 0
+    pattern[ydead, xdead] = 0
 
     return pattern
 

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -21,17 +21,6 @@ import numpy as np
 from numpy.random import default_rng
 from scipy import ndimage as ndi
 
-
-def _process_seed_argument(seed):
-    """ Sets up a numpy random number generator with a seed"""
-    if seed is not None:
-        rng = default_rng(seed)
-    else:
-        rng = default_rng()
-
-    return rng
-
-
 def constrain_to_dynamic_range(pattern, detector_max=None):
     """Force the values within pattern to lie between [0,detector_max]
 
@@ -96,7 +85,7 @@ def add_shot_noise(pattern, seed=None):
     This function will (as it should) behave differently depending on the
     pattern intensity, so be mindful to put your intensities in physical units
     """
-    rng = _process_seed_argument(seed)
+    rng = default_rng(seed)
 
     return rng.poisson(pattern)
 
@@ -153,7 +142,7 @@ def add_gaussian_noise(pattern, sigma, seed=None):
     -------
     corrupted_pattern :
     """
-    rng = _process_seed_argument(seed)
+    rng = default_rng(seed)
     pertubations = rng.normal(loc=0, scale=sigma, size=pattern.shape)
     pattern = pattern + pertubations
 
@@ -193,8 +182,7 @@ def add_dead_pixels(pattern, n=None, fraction=None, seed=None):
         pattern_size = pattern.shape[0] * pattern.shape[1]
         n = int(fraction * pattern_size)
 
-    rng = _process_seed_argument(seed)
-
+    rng = default_rng(seed)
     # .astype rounds down, these generate values from 0 to (pattern.shape - 1)
     xdead = rng.uniform(low=0, high=pattern.shape[0], size=n).astype(int)
     ydead = rng.uniform(low=0, high=pattern.shape[1], size=n).astype(int)

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -27,14 +27,14 @@ def constrain_to_dynamic_range(pattern, detector_max=None):
 
     Parameters
     ----------
-    pattern : np.ndarray
+    pattern : numpy.ndarray
         The diffraction pattern at the detector after corruption
     detector_max : float
         The maximum allowed value at the detector
 
     Returns
     -------
-    within_range_pattern: np.ndarray
+    within_range_pattern: numpy.ndarray
         The pattern, with values >=0 and =< detector_max
     """
     within_range = pattern.copy()

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -47,12 +47,13 @@ def constrain_to_dynamic_range(pattern, detector_max=None):
     within_range_pattern: np.ndarray
         The pattern, with values >=0 and =< detector_max
     """
-    pattern[pattern < 0] = 0
+    within_range = pattern.copy()
+    within_range[within_range < 0] = 0
 
     if detector_max is not None:
-        pattern[pattern > detector_max] = detector_max
+        within_range[within_range > detector_max] = detector_max
 
-    return pattern
+    return within_range
 
 
 def add_gaussian_point_spread(pattern, sigma):

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2.dev"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2020, The pyXem Developers"
 credits = [

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -41,17 +41,42 @@ def test_constrain_to_dynamic_range(pattern):
     dmax = int(max / 3)
     z = constrain_to_dynamic_range(pattern, detector_max=dmax)
     assert np.max(z) == dmax
+    assert not np.may_share_memory(pattern,z)
+
+class TestReturnsareCopies:
+    """ We want pattern to remain untouched by the noise addition """
+    
+    def test_copy_shot_and_point_spread(self,pattern):
+        """ Also covers shot/point independantly """
+        z = add_shot_and_point_spread(pattern, 2, shot_noise=True)
+        assert not np.may_share_memory(pattern,z)
+
+    def test_copy_gaussian(self,pattern):
+        z = add_gaussian_noise(pattern,2)
+        assert not np.may_share_memory(pattern,z)
+
+    def test_copy_gain_and_offset(self,pattern):
+        zgain = add_linear_detector_gain(pattern,1.1)
+        zoff = add_detector_offset(pattern,0.1)
+        assert not np.may_share_memory(pattern,zgain)
+        assert not np.may_share_memory(pattern,zoff)
+
+    def test_copy_deadpixel(self,pattern):
+        pattern = pattern + 1  # so that we can detect dead pixels
+        z = add_dead_pixels(pattern, n=6, seed=7)
+        assert not np.may_share_memory(pattern,z)
 
 
-def test_add_shot_and_point_spread(pattern):
-    z = add_shot_and_point_spread(pattern, 0, shot_noise=False)
-    assert np.allclose(z, pattern)
-    # seed testing so we can go through shot_noise = True
-    z1a = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=7)
-    z1b = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=7)
-    z2 = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=8)
-    assert np.allclose(z1a, z1b)
-    assert not np.allclose(z1a, z2)
+class TestShotAndPointSpread:
+    def test_add_shot_and_point_spread(self,pattern):
+        z = add_shot_and_point_spread(pattern, 0, shot_noise=False)
+        assert np.allclose(z, pattern)
+        # seed testing so we can go through shot_noise = True
+        z1a = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=7)
+        z1b = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=7)
+        z2 = add_shot_and_point_spread(pattern, 2, shot_noise=True, seed=8)
+        assert np.allclose(z1a, z1b)
+        assert not np.allclose(z1a, z2)
 
 
 class TestShotNoise:

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -41,34 +41,35 @@ def test_constrain_to_dynamic_range(pattern):
     dmax = int(max / 3)
     z = constrain_to_dynamic_range(pattern, detector_max=dmax)
     assert np.max(z) == dmax
-    assert not np.may_share_memory(pattern,z)
+    assert not np.may_share_memory(pattern, z)
+
 
 class TestReturnsareCopies:
     """ We want pattern to remain untouched by the noise addition """
-    
-    def test_copy_shot_and_point_spread(self,pattern):
+
+    def test_copy_shot_and_point_spread(self, pattern):
         """ Also covers shot/point independantly """
         z = add_shot_and_point_spread(pattern, 2, shot_noise=True)
-        assert not np.may_share_memory(pattern,z)
+        assert not np.may_share_memory(pattern, z)
 
-    def test_copy_gaussian(self,pattern):
-        z = add_gaussian_noise(pattern,2)
-        assert not np.may_share_memory(pattern,z)
+    def test_copy_gaussian(self, pattern):
+        z = add_gaussian_noise(pattern, 2)
+        assert not np.may_share_memory(pattern, z)
 
-    def test_copy_gain_and_offset(self,pattern):
-        zgain = add_linear_detector_gain(pattern,1.1)
-        zoff = add_detector_offset(pattern,0.1)
-        assert not np.may_share_memory(pattern,zgain)
-        assert not np.may_share_memory(pattern,zoff)
+    def test_copy_gain_and_offset(self, pattern):
+        zgain = add_linear_detector_gain(pattern, 1.1)
+        zoff = add_detector_offset(pattern, 0.1)
+        assert not np.may_share_memory(pattern, zgain)
+        assert not np.may_share_memory(pattern, zoff)
 
-    def test_copy_deadpixel(self,pattern):
+    def test_copy_deadpixel(self, pattern):
         pattern = pattern + 1  # so that we can detect dead pixels
         z = add_dead_pixels(pattern, n=6, seed=7)
-        assert not np.may_share_memory(pattern,z)
+        assert not np.may_share_memory(pattern, z)
 
 
 class TestShotAndPointSpread:
-    def test_add_shot_and_point_spread(self,pattern):
+    def test_add_shot_and_point_spread(self, pattern):
         z = add_shot_and_point_spread(pattern, 0, shot_noise=False)
         assert np.allclose(z, pattern)
         # seed testing so we can go through shot_noise = True


### PR DESCRIPTION
---
name: Patching the detector_functions module (see review of #143)
about: This makes some nice docstring changes, removes a needless private function (numpy already knew what it was doing) and make+tests all our methods do not alter the pattern that they are given.

---

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
