### PR TITLE
added pattern-to-mask feature

### DIFF
--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -160,7 +160,7 @@ class DiffractionSimulation:
         if radius_function is not None:
             r = radius_function(self.intensities, *args, **kwargs)
         mask = mask_utils.create_mask(shape, fill=negative)
-        mask_utils.add_circles_to_mask(point_coordinates_shifted, r, mask,
+        mask_utils.add_circles_to_mask(mask, point_coordinates_shifted, r,
                                     fill=not negative)
         return mask
 

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -174,6 +174,20 @@ class TestDiffractionSimulation:
         )
         z = empty_sim.get_diffraction_pattern(size=10)
 
+    def test_get_as_mask(self):
+        short_sim = DiffractionSimulation(
+            coordinates=np.asarray([[0.3, 1.2, 0]]),
+            intensities=np.ones(1),
+            calibration=[1, 2],
+        )
+        mask = short_sim.get_as_mask((20, 10),
+                                     radius_function=np.sqrt,
+                                     direct_beam_position=(10, 6)
+                                     )
+        assert mask.shape[0] == 20
+        assert mask.shape[1] == 10
+        
+
     @pytest.mark.parametrize("units_in",['pixel','real'])
     def test_plot_method(self,units_in):
         short_sim = DiffractionSimulation(

--- a/diffsims/tests/utils/test_mask_utils.py
+++ b/diffsims/tests/utils/test_mask_utils.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2021 The diffsims developers
+#
+# This file is part of diffsims.
+#
+# diffsims is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# diffsims is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
 from diffsims.utils import mask_utils as mu
 import numpy as np
 

--- a/diffsims/tests/utils/test_mask_utils.py
+++ b/diffsims/tests/utils/test_mask_utils.py
@@ -1,0 +1,42 @@
+from diffsims.utils import mask_utils as mu
+import numpy as np
+
+
+def test_create_mask():
+    mask = mu.create_mask((20, 10))
+    assert mask.shape[0] == 20
+    assert mask.shape[1] == 10
+
+
+def test_invert_mask():
+    mask = mu.create_mask((20, 10))
+    initial = mask[0,0]
+    mu.invert_mask(mask)
+    assert initial != mask[0,0]
+
+
+def test_add_polygon():
+    mask = mu.create_mask((20, 10))
+    coords = np.array([[5, 5],[15, 5],[10,10]])
+    mu.add_polygon_to_mask(mask, coords)
+
+
+def test_add_circles_to_mask():
+    mask = mu.create_mask((20, 10))
+    coords = np.array([[5, 5],[15, 5],[10,10]])
+    mu.add_circles_to_mask(mask, coords, 3)
+    
+
+def test_add_circle_to_mask():
+    mask = mu.create_mask((20, 10))
+    mu.add_circle_to_mask(mask, 5, 5, 5)
+
+
+def test_add_annulus_to_mask():
+    mask = mu.create_mask((20, 10))
+    mu.add_annulus_to_mask(mask, 4, 7)
+
+
+def test_add_band_to_mask():
+    mask = mu.create_mask((20, 10))
+    mu.add_band_to_mask(mask, 4, 7, 10, 4)

--- a/diffsims/utils/__init__.py
+++ b/diffsims/utils/__init__.py
@@ -31,6 +31,7 @@ from diffsims.utils import (
     shape_factor_models,
     sim_utils,
     vector_utils,
+    mask_utils,
 )
 
 __all__ = [
@@ -46,4 +47,5 @@ __all__ = [
     "shape_factor_models",
     "sim_utils",
     "vector_utils",
+    "mask_utils",
 ]

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2021 The diffsims developers
+#
+# This file is part of diffsims.
+#
+# diffsims is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# diffsims is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
+
 from PIL import ImageDraw
 from PIL import Image
 import numpy as np

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 
 def create_mask(shape, fill=True):
     """
-    Instantiate an empty mask
+    Initiate an empty mask
     """
     return np.full(shape, fill, dtype=bool)
 
@@ -19,7 +19,7 @@ def invert_mask(mask):
 
 def add_polygon_to_mask(mask, coords, fill=False):
     """
-    Add a poligon defined by sequential vertex coordinates to the mask.
+    Add a polygon defined by sequential vertex coordinates to the mask.
 
     Parameters
     ----------

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -29,6 +29,11 @@ def add_polygon_to_mask(mask, coords, fill=False):
         (x, y) coordinates of vertices
     fill: int, optional
         Fill value. 0 is black (negative, False) and 1 is white (True)
+
+    Returns
+    -------
+    None:
+        the mask is adjusted inplace
     """
     coords = np.array(coords)
     coords = np.ravel(coords, order='C').tolist()
@@ -52,6 +57,11 @@ def add_circles_to_mask(mask, coords, r, fill=False):
         radii of the circles
     fill: int, optional
         Fill value. 0 is black (negative, False) and 1 is white (True)
+
+    Returns
+    -------
+    None:
+        the mask is adjusted inplace
     """
     coords = np.array(coords)
     r = r*np.ones(coords.shape[0])
@@ -78,8 +88,8 @@ def add_circle_to_mask(mask, x, y, r, fill=False):
 
     Returns
     -------
-    mask: (H, W) array of dtype bool
-        The array with the new addition
+    None:
+        the mask is adjusted inplace
     """
     xx = np.arange(mask.shape[1])
     yy = np.arange(mask.shape[0])
@@ -106,6 +116,11 @@ def add_annulus_to_mask(mask, r1, r2, x=None, y=None, fill=False):
         y-coordinate of the circle center in pixels. Defaults to the center of the mask.
     fill: int, optional
         Fill value. 0 is black (block, False) and 1 is white (pass, True)
+
+    Returns
+    -------
+    None:
+        the mask is adjusted inplace
     """
     if x is None:
         x = mask.shape[1] / 2
@@ -138,6 +153,11 @@ def add_band_to_mask(mask, x, y, theta, width, fill=False):
         width of the band in pixels
     fill: int, optional
         Fill value. 0 is black (block, False) and 1 is white (pass, True)
+
+    Returns
+    -------
+    None:
+        the mask is adjusted inplace
     """
     # see distance from point to line formula https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
     theta_r = np.deg2rad(theta)

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -1,0 +1,118 @@
+from PIL import ImageDraw
+from PIL import Image
+import numpy as np
+
+
+def create_mask(shape, fill=True):
+    """
+    Instantiate an empty mask
+    """
+    return np.full(shape, fill, dtype=np.bool)
+
+
+def invert_mask(mask):
+    """
+    Turn True into False and False into True
+    """
+    mask[:] = np.invert(mask)
+
+
+def add_polygon_to_mask(coords, mask, fill=False):
+    """
+    Add a poligon defined by sequential vertex coordinates to the mask.
+
+    Parameters
+    ----------
+    coords: (N, 2) array
+        (x, y) coordinates of vertices
+    mask: (H, W) array of dtype bool
+        boolean mask for an image
+    fill: int, optional
+        Fill value. 0 is black (negative, False) and 1 is white (True)
+    """
+    coords = np.array(coords)
+    coords = np.ravel(coords, order='C').tolist()
+    tempmask = Image.fromarray(mask)
+    draw = ImageDraw.Draw(tempmask)
+    draw.polygon(coords, fill=fill)
+    mask[:] = np.array(tempmask, dtype=np.bool)
+
+
+def add_circles_to_mask(coords, r, mask, fill=False):
+    """
+    Add a circle on a mask at each (x, y) coordinate with a radius r
+
+    Parameters
+    ----------
+    coords: (N, 2) array
+        (x, y) coordinates of circle centers
+    r: float or (N,) array
+        radii of the circles
+    mask: (H, W) array of dtype bool
+        boolean mask for an image
+    fill: int, optional
+        Fill value. 0 is black (negative, False) and 1 is white (True)
+    """
+    coords = np.array(coords)
+    r = r*np.ones(coords.shape[0])
+    for i, j in zip(coords, r):
+        add_circle_to_mask(i[0], i[1], j, mask, fill=fill)
+
+
+def add_circle_to_mask(x, y, r, mask, fill=False):
+    """
+    Add a single circle to the mask
+
+    Parameters
+    ----------
+    x: float
+        x-coordinate of the circle center in pixels
+    y: float
+        y-coordinate of the circle center in pixels
+    r: float
+        radius of the circles in pixels
+    mask: (H, W) array of dtype bool
+        boolean mask for an image
+    fill: int, optional
+        Fill value. 0 is black (negative, False) and 1 is white (True)
+
+    Returns
+    -------
+    mask: (H, W) array of dtype bool
+        The array with the new addition
+    """
+    xx = np.arange(mask.shape[1])
+    yy = np.arange(mask.shape[0])
+    X, Y = np.meshgrid(xx, yy)
+    condition = ((X - x)**2 + (Y - y)**2 < r**2)
+    mask[condition] = fill
+
+
+def add_annulus_to_mask(r1, r2, mask, x=None, y=None, fill=False):
+    """
+    Add an annular feature on the mask
+
+    Parameters
+    ----------
+    r1: float
+        radius of the inner circle in pixels
+    r2: float
+        radius of the outer circle in pixels
+    mask: (H, W) array of dtype bool
+        boolean mask for an image
+    x: float
+        x-coordinate of the circle center in pixels. Defaults to the center of the mask.
+    y: float
+        y-coordinate of the circle center in pixels. Defaults to the center of the mask.
+    fill: int, optional
+        Fill value. 0 is black (block, False) and 1 is white (pass, True)
+    """
+    if x is None:
+        x = mask.shape[1] / 2
+    if y is None:
+        y = mask.shape[0] / 2
+    xx = np.arange(mask.shape[1])
+    yy = np.arange(mask.shape[0])
+    X, Y = np.meshgrid(xx, yy)
+    condition = ((X - x)**2 + (Y - y)**2 > r1**2) & ((X - x)**2 + (Y - y)**2 < r2**2)
+    mask[condition] = fill


### PR DESCRIPTION
---
name: Template to binary mask
about: Implemented a small feature whereby a template can be converted to corresponding binary mask of circles.

---

**Release Notes**
* Added a method `get_as_mask` in `DiffractionSimulation` with a number of options
* Added a module `mask_utils` under utils. 

**What does this PR do? Please describe and/or link to an open issue.**
For my work I would like to easily generate masks from templates to perform multi-stage indexations. I always implemented this in hacky ways but decided it would be handy if `DiffractionSimulation` would have a method that converts it to a binary mask, similar as it can be converted to an image of Gaussians.

A simple example:
```python
import diffpy
from diffsims.generators.diffraction_generator import DiffractionGenerator

aus = diffpy.structure.loadStructure("austeniteLP.cif")
diff_gen = DiffractionGenerator(accelerating_voltage=200, shape_factor_model="lorentzian")

orientation = [0, 20, 45]
simulation = diff_gen.calculate_ed_data(aus,
                                        2.3,
                                        orientation,
                                        with_direct_beam=False,
                                        max_excitation_error=1e-1,
                                        )
simulation.calibration = 0.012

mask = simulation.get_as_mask((256, 256), radius = 10)
```
Plotting the simulated coordinates produces:
![afbeelding](https://user-images.githubusercontent.com/25320842/109855190-4619e300-7c58-11eb-97d1-7901e3f5b69e.png)

The image of the mask: 
![afbeelding](https://user-images.githubusercontent.com/25320842/109855028-12d75400-7c58-11eb-9594-1f1dbd6b7505.png)

One can specify whether one wants a "negative" or a "positive" mask. The radii of the circles can also be controlled - each can be set individually by passing an array into `radius` or the radius can be determined based on a function of the intensity, which can be passed in as `radius_function`.

Modifications can be made to the mask using additional functions in `mask_utils`. I added support for drawing a circle, any polygon, and an annulus. The functions work in-place, e.g.

```python
from pyxem.utils import mask_utils as mu
mask = mu.create_mask((512, 512))
mu.add_annulus_to_mask(150, 250, mask)
mu.add_circle_to_mask(256, 50, 30, mask, fill=True)
coords = np.array([[200, 200],
                   [350, 100],
                   [250, 350]])
mu.add_polygon_to_mask(coords, mask)
```
This produces a mask:
![afbeelding](https://user-images.githubusercontent.com/25320842/109856165-7910a680-7c59-11eb-8a49-b6596cbc7313.png)

Maybe I didn't search hard enough, but I couldn't find these convenience functions to generate a mask in other packages.

**Describe alternatives you've considered**
I'm unsure whether the `mask_utils` fit all that well in diffsims and they would probably fit better in pyxem. On the other hand, I like that `get_as_mask` function being under `DiffractionSimulation`.

**Are there any known issues? Do you need help?**
I would say it's fully functional but a discussion may be needed on where to best place things. Also unit tests are still needed.

A lazy implementation using e.g. dask.futures or dask.delayed might be handy to generate a 4D-STEM sized mask without having it in memory. 

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Unit testing
- [ ] Find a good place for mask functions

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
