### PR TITLE
fixed rotation list bug, changed default grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- `get_grid_beam_directions` default meshing changed to "spherified_cube_edge" from "spherified_cube_corner"
+
+### Fixed
+- `get_grid_beam_directions` now behaves correctly for the triclinic and monoclinic cases
+- 
 ## 2020-01-11 - version 0.4.0
 ### Changed
 - `get_grid_beam_directions`, now works based off of meshes

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.4.0"
+version = "0.4.1.dev"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2021, The pyXem Developers"
 credits = [


### PR DESCRIPTION
---
name: Fixes rotation grids
about: See issue #155 

---

**Release Notes**
* Fixed the list of rotations for the triclinic and monoclinic case
* Changed the default grid type as this looked more natural

Monoclinic grid:
![afbeelding](https://user-images.githubusercontent.com/25320842/109954499-b3258b00-7ce1-11eb-8168-f41f5f8ff253.png)

Triclinic grid:

Spherified_cube_edge (new default)
![afbeelding](https://user-images.githubusercontent.com/25320842/109954535-bcaef300-7ce1-11eb-9675-5359f37111c8.png)

Spherified_cube_corner (old default)
![afbeelding](https://user-images.githubusercontent.com/25320842/109954684-e9630a80-7ce1-11eb-89a4-b612abe0a1d4.png)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
