### PR TITLE
Add in-plane angle to mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added 
-- Simulations now have a .get_as_mask() method (#154)
+- Simulations now have a .get_as_mask() method (#154, #158)
 
 ## 2021-03-15 - version 0.4.1
 

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -160,7 +160,7 @@ class DiffractionSimulation:
         point_coordinates_shifted = self.calibrated_coordinates[:, :-1].copy()
         x = point_coordinates_shifted[:, 0]
         y = point_coordinates_shifted[:, 1]
-        theta = np.arctan2(y, x) + in_plane_angle
+        theta = np.arctan2(y, x) + np.deg2rad(in_plane_angle)
         rd = np.sqrt(x**2 + y**2)
         point_coordinates_shifted[:, 0] = rd * np.cos(theta) + cx
         point_coordinates_shifted[:, 1] = rd * np.sin(theta) + cy

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -127,6 +127,7 @@ class DiffractionSimulation:
 
     def get_as_mask(self, shape, radius=6., negative=True,
                     radius_function=None, direct_beam_position=None,
+                    in_plane_angle=0,
                     *args, **kwargs):
         """
         Return the diffraction pattern as a binary mask of type
@@ -149,14 +150,20 @@ class DiffractionSimulation:
         direct_beam_position: 2-tuple of ints, optional
             The (x,y) coordinate in pixels of the direct beam. Defaults to
             the center of the image.
+        in_plane_angle: float, optional
+            In plane rotation of the pattern in degrees
         """
         r = radius
         cx, cy = shape[0]//2, shape[1]//2
         if direct_beam_position is not None:
             cx, cy = direct_beam_position
         point_coordinates_shifted = self.calibrated_coordinates[:, :-1].copy()
-        point_coordinates_shifted[:, 0] += cx
-        point_coordinates_shifted[:, 1] += cy
+        x = point_coordinates_shifted[:, 0]
+        y = point_coordinates_shifted[:, 1]
+        theta = np.arctan2(y, x) + in_plane_angle
+        rd = np.sqrt(x**2 + y**2)
+        point_coordinates_shifted[:, 0] = rd * np.cos(theta) + cx
+        point_coordinates_shifted[:, 1] = rd * np.sin(theta) + cy
         if radius_function is not None:
             r = radius_function(self.intensities, *args, **kwargs)
         mask = mask_utils.create_mask(shape, fill=negative)


### PR DESCRIPTION
---
name: In plane angle for mask
about: Adds a small feature whereby a mask generated from a template can be given an additional in-plane rotation.

---

**Release Notes**
Adds a small feature whereby a mask generated from a template can be given an additional in-plane rotation.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Tests probably need updating

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
