### PR TITLE
Fixing and improving the precession simulations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8,3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 - Simulations now have a .get_as_mask() method (#154, #158)
 
-## 2021-03-15 - version 0.4.1
+### Fixed 
+- Precession simulations (#161)
 
+## 2021-03-15 - version 0.4.1
 ### Changed
 - `get_grid_beam_directions` default meshing changed to "spherified_cube_edge" from "spherified_cube_corner"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2021-04-16 - version 0.4.2
 
 ### Added 
 - Simulations now have a .get_as_mask() method (#154, #158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - Simulations now have a .get_as_mask() method (#154, #158)
+- Python 3.9 testing (#161)
 
 ### Fixed 
 - Precession simulations (#161)
+
+### Changed
+- Simulations now use a fractional (rather than absolute) min_intensity (#161)
 
 ## 2021-03-15 - version 0.4.1
 ### Changed

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -64,7 +64,7 @@ def _shape_factor_precession(
     r_spot : np.ndarray (N,)
         An array representing the distance of spots from the z-axis in A^-1
     phi : float
-        The precession angle in degrees
+        The precession angle in radians
     shape_function : callable
         A function that describes the influence from the rel-rods. Should be
         in the form func(excitation_error: np.ndarray, max_excitation: float,
@@ -92,7 +92,7 @@ def _shape_factor_precession(
         def integrand(theta):
             # Equation 8 in L.Palatinus et al. Acta Cryst. (2019) B75, 512-522
             S_zero = excitation_error_i
-            variable_term = r_spot_i*np.deg2rad(phi)*np.cos(theta)
+            variable_term = r_spot_i*(phi)*np.cos(theta)
             return shape_function(S_zero + variable_term, max_excitation, **kwargs)
 
         # average factor integrated over the full revolution of the beam

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -285,7 +285,7 @@ class DiffractionGenerator(object):
         # Obtain crystallographic reciprocal lattice points within `reciprocal_radius` and
         # g-vector magnitudes for intensity calculations.
         recip_latt = latt.reciprocal()
-        spot_indices, cartesian_coordinates, spot_distances = get_points_in_sphere(
+        g_indices, intersection_coordinates, g_distances = get_points_in_sphere(
             recip_latt, reciprocal_radius
         )
 
@@ -314,11 +314,6 @@ class DiffractionGenerator(object):
             r_spot = r_spot[intersection]
             g_indices = spot_indices[intersection]
             g_hkls = spot_distances[intersection]
-
-        else:
-            intersection_coordinates = cartesian_coordinates
-            g_indices = spot_indices
-            g_hkls = spot_distances
 
         # take into consideration rel-rods
         if self.precession_angle > 0 and not self.approximate_precession:

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -188,7 +188,7 @@ class DiffractionGenerator(object):
         are available via strings.
     approximate_precession : boolean
         When using precession, whether to precisely calculate average
-        excitation errors and intensities or use an approximation. See notes.
+        excitation errors and intensities or use an approximation.
     minimum_intensity : float
         Minimum intensity for a peak to be considered visible in the pattern (fractional from the maximum)
     kwargs :
@@ -196,8 +196,6 @@ class DiffractionGenerator(object):
 
     Notes
     -----
-    * A full calculation is much slower and is not recommended for calculating
-      a diffraction library for precession diffraction patterns.
     * When using precession and approximate_precession=True, the shape factor
     model defaults to Lorentzian; shape_factor_model is ignored. Only with
     approximate_precession=False the custom shape_factor_model is used.

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -224,7 +224,7 @@ class DiffractionGenerator(object):
         # Obtain crystallographic reciprocal lattice points within `reciprocal_radius` and
         # g-vector magnitudes for intensity calculations.
         recip_latt = latt.reciprocal()
-        g_indices, intersection_coordinates, g_distances = get_points_in_sphere(
+        g_indices, cartesian_coordinates, g_distances = get_points_in_sphere(
             recip_latt, reciprocal_radius
         )
 
@@ -247,7 +247,7 @@ class DiffractionGenerator(object):
         if self.precession_angle == 0:
             # Mask parameters corresponding to excited reflections.
             intersection = np.abs(excitation_error) < max_excitation_error
-            intersection_coordinates = intersection_coordinates[intersection]
+            intersection_coordinates = cartesian_coordinates[intersection]
             excitation_error = excitation_error[intersection]
             r_spot = r_spot[intersection]
             g_indices = g_indices[intersection]
@@ -258,6 +258,8 @@ class DiffractionGenerator(object):
                 excitation_error, max_excitation_error, **self.shape_factor_kwargs
             )
         else:
+            intersection_coordinates = cartesian_coordinates #for naming simplicity
+            
             if self.approximate_precession:
                 shape_factor = lorentzian_precession(
                     excitation_error,

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.5.0-dev"
+version = "0.4.2-dev"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2021, The pyXem Developers"
 credits = [

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.4.2-dev"
+version = "0.4.2"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2021, The pyXem Developers"
 credits = [

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -23,9 +23,7 @@ from diffsims.sims.diffraction_simulation import ProfileSimulation
 from diffsims.generators.diffraction_generator import (
     DiffractionGenerator,
     AtomicDiffractionGenerator,
-    _z_sphere_precession,
     _shape_factor_precession,
-    _average_excitation_error_precession,
 )
 import diffpy.structure
 from diffsims.utils.shape_factor_models import linear, binary, sin2c, atanc, lorentzian
@@ -103,35 +101,11 @@ def probe(x, out=None, scale=None):
         v = v * abs(x[1].reshape(1, -1, 1)) < 6
         return v + 0 * x[2].reshape(1, 1, -1)
 
-
-@pytest.mark.parametrize(
-    "parameters, expected",
-    [
-        ([0, 1, 0.001, 0.5], -0.00822681491001731),
-        (
-            [0, np.array([1, 2, 20]), 0.001, 0.5],
-            np.array([-0.00822681, -0.01545354, 0.02547058]),
-        ),
-        ([180, 1, 0.001, 0.5], 0.00922693),
-    ],
-)
-def test_z_sphere_precession(parameters, expected):
-    result = _z_sphere_precession(*parameters)
-    assert np.allclose(result, expected)
-
-
 @pytest.mark.parametrize("model", [binary, linear, atanc, sin2c, lorentzian])
 def test_shape_factor_precession(model):
-    z = np.array([-0.1, 0.1])
+    excitation = np.array([-0.1, 0.1])
     r = np.array([1, 5])
-    _ = _shape_factor_precession(z, r, 0.001, 0.5, model, 0.1)
-
-
-def test_average_excitation_error_precession():
-    z = np.array([-0.1, 0.1])
-    r = np.array([1, 5])
-    _ = _average_excitation_error_precession(z, r, 0.001, 0.5)
-
+    _ = _shape_factor_precession(excitation, r, 0.5, model, 0.1)
 
 @pytest.mark.parametrize(
     "model, expected",

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -199,6 +199,6 @@ def lorentzian_precession(
     """
     sigma = np.pi / max_excitation_error
     u = sigma ** 2 * (r_spot ** 2 * precession_angle ** 2 - excitation_error ** 2) + 1
-    z = np.sqrt(u ** 2 + 4 * sigma ** 2 + excitation_error ** 2)
+    z = np.sqrt(u ** 2 + 4 * sigma ** 2 * excitation_error ** 2)
     fac = (sigma / np.pi) * np.sqrt(2 * (u + z) / z ** 2)
     return fac

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -185,7 +185,7 @@ def lorentzian_precession(
         The distance (reciprocal) from each reflection to the origin
 
     precession_angle : float
-        The beam precession angle in degrees; the angle the beam makes
+        The beam precession angle in radians; the angle the beam makes
         with the optical axis.
 
     Returns


### PR DESCRIPTION
---
name: Fixing and improving the precession simulations 
about: This constitutes a substantial rewriting of both routes to precession, they should now be consistent with one another and more correct.

---

**What does this PR do? Please describe and/or link to an open issue.**
Several changes were needed for this fix, including:
(for the approximation case)
- conversion of the precession angle to radians
- correcting the formulae in `lorentzian_precession`
- correcting the erroneous use of `max_excitation_error` (discussion in #159)

(for the full case)
- completely rewritten to follow the form in the main reference (see #160)

(general)
- some internal reorderings for readability
- docstring improvements
 
#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
