### PR TITLE
Explicity state Python 3.9 support, increase minimal version of NumPy to >= 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8,3.9]
+        python-version: [3.8, 3.9]
+        include:
+          # Oldest supported version of main dependencies on Python 3.6
+          - os: ubuntu-latest
+            python-version: 3.6
+            OLDEST_SUPPORTED_VERSION: true
+            # orix requires matplotlib 3.3, matplotlib 3.3 requires numpy 1.15
+            # numba requires scipy==1.0
+            # scipy==0.15 throws ufunc error
+            DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.5.0 scipy==1.0 tqdm==4.9
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,6 +34,9 @@ jobs:
       - name: Install depedencies and package
         shell: bash
         run: pip install -U -e .'[tests]'
+      - name: Install oldest supported version
+        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        run: pip install ${{ matrix.DEPENDENCIES }}
       - name: Run tests
         run: pytest --cov=diffsims --pyargs diffsims
       - name: Generate line coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Minimal version of dependencies: numpy >= 1.17, scipy >= 0.15, tqdm >= 4.9
+
 ## 2021-04-16 - version 0.4.2
 
-### Added 
+### Added
 - Simulations now have a .get_as_mask() method (#154, #158)
 - Python 3.9 testing (#161)
 
-### Fixed 
+### Fixed
 - Precession simulations (#161)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Minimal version of dependencies: numpy >= 1.17, scipy >= 0.15, tqdm >= 4.9
+- Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9
 
 ## 2021-04-16 - version 0.4.2
 

--- a/README.rst
+++ b/README.rst
@@ -20,23 +20,25 @@
 
 diffsims is an open-source python library for simulating diffraction.
 
-If simulations performed using diffsims form a part of published work please cite the DOI at the top of this page.
+If simulations performed using diffsims form a part of published work please
+cite the DOI at the top of this page.
 
 diffsims is released under the GPL v3 license.
-
 
 Installation
 ------------
 
-diffsims requires python 3 and conda - we suggest using the python 3 version of `Miniconda <https://conda.io/miniconda.html>`__ and creating a new environment for diffsims using the following commands in the anaconda prompt:::
+diffsims requires python 3 and conda - we suggest using the python 3 version of
+`Miniconda <https://conda.io/miniconda.html>`__ and creating a new environment
+for diffsims using the following commands in the anaconda prompt::
 
-      $ conda create -n diffsims
-      $ conda activate diffsims
+$ conda create -n diffsims
+$ conda activate diffsims
 
-The recommended way to install diffsims is then from conda-forge using:::
+The recommended way to install diffsims is then from conda-forge using::
 
-      $ conda install -c conda-forge diffsims
+$ conda install -c conda-forge diffsims
 
-Note that diffsims is also available via pip:::
+Note that diffsims is also available via pip::
 
-      $ pip install diffsims
+$ pip install diffsims

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extra_feature_requirements["dev"] = ["black >= 19.3b0", "pre-commit >= 1.16"] + 
 setup(
     name=name,
     version=version,
-    description="Diffraction Simulations in Python.",
+    description="Diffraction Simulations in Python",
     author=author,
     author_email=email,
     license=license,
@@ -45,6 +45,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -55,17 +57,16 @@ setup(
     ],
     packages=find_packages(),
     extras_require=extra_feature_requirements,
-    # adjust the tabbing
     install_requires=[
-        "scipy>=0.15",
-        "numpy>=1.10",
-        "matplotlib>=3.1.1",
-        "tqdm>=0.4.9",
-        "transforms3d",
-        "diffpy.structure>=3.0.0",  # First Python 3 support
-        "orix>=0.5.0",
+        "diffpy.structure >= 3.0.0",  # First Python 3 support
+        "matplotlib >= 3.1.1",
         "numba",
+        "numpy >= 1.17",
+        "orix >= 0.5.0",
         "psutil",
+        "scipy >= 0.15",
+        "tqdm >= 4.9",
+        "transforms3d",
     ],
     python_requires=">=3.6",
     package_data={


### PR DESCRIPTION
* Update setup.py to reflect support for Python 3.8 and 3.9
* Increase minimal version of NumPy to >= 1.17 because of use of `numpy.random.default_rng`
* I think minimal version of tqdm 0.4.9 was a typo, changed to 4.9
* Build only on Python 3.8 and 3.9, but add a minimal dependencies step on Python 3.6. Note that to get this step to work, compatible versions of minimal dependencies must be installed, or else `pip` raises an incompatibility error. These versions are then: `pip install diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.5.0 scipy==1.0 tqdm==4.9`
* Touch up README
* Update changelog

Close #164.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
