### PR TITLE
Added ignore atomic scatter option + bugfixes precession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Option to use None for `scattering_params` which ignores atomic scattering
+
 ### Changed
 - Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9
 

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -233,13 +233,13 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_e
         return beam_directions_grid_to_euler(points_in_cartesians)
     if crystal_system == "monoclinic":
         points_in_cartesian = points_in_cartesians[
-                np.dot(np.array([0,0,1]), points_in_cartesians.T) >= epsilon
-                ]
+            np.dot(np.array([0, 0, 1]), points_in_cartesians.T) >= epsilon
+        ]
         points_in_cartesian = points_in_cartesians[
-                np.dot(np.array([1,0,0]), points_in_cartesians.T) >= epsilon
-                ]
+            np.dot(np.array([1, 0, 0]), points_in_cartesians.T) >= epsilon
+        ]
         return beam_directions_grid_to_euler(points_in_cartesian)
-        
+
     # for all other systems, determine it from the triangle vertices
     corners = crystal_system_dictionary[crystal_system]
     a, b, c = corners[0], corners[1], corners[2]

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -324,7 +324,14 @@ def test_get_intensities_params(default_structure):
     np.testing.assert_array_equal(unique_hkls, [[-0.0, -0.0, 0.0]])
 
 
-def test_get_kinematical_intensities(default_structure):
+@pytest.mark.parametrize(
+    "scattering_params, answer",
+    [
+        ("lobato", 43.0979),
+        (None, 1.0),
+    ],
+)
+def test_get_kinematical_intensities(default_structure, scattering_params, answer):
     latt = default_structure.lattice
     reciprocal_lattice = latt.reciprocal()
     reciprocal_radius = 0.2
@@ -338,6 +345,6 @@ def test_get_kinematical_intensities(default_structure):
         g_hkls_array=g_hkls_array,
         debye_waller_factors={"Al": 1},
         prefactor=multiplicites,
-        scattering_params="lobato",
+        scattering_params=scattering_params,
     )
-    np.testing.assert_array_almost_equal(i_hkls, ([43.0979]), decimal=4)
+    np.testing.assert_array_almost_equal(i_hkls, ([answer]), decimal=4)

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -38,6 +38,7 @@ def binary(excitation_error, max_excitation_error):
     return 1
 
 
+@np.vectorize
 def linear(excitation_error, max_excitation_error):
     """
     Returns an intensity linearly scaled with by the excitation error
@@ -55,7 +56,8 @@ def linear(excitation_error, max_excitation_error):
     intensities : array-like or float
     """
     sf = 1 - np.abs(excitation_error) / max_excitation_error
-    sf[sf < 0.0] = 0.0
+    if sf < 0.:
+        sf = 0.
     return sf
 
 

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -161,7 +161,11 @@ def lorentzian(excitation_error, max_excitation_error):
     # in the paper, sigma = pi*thickness.
     # We assume thickness = 1/max_exitation_error
     sigma = np.pi / max_excitation_error
-    fac = sigma / (np.pi * (sigma ** 2 * excitation_error ** 2 + 1))
+    fac = (
+        sigma
+        / (np.pi * (sigma ** 2 * excitation_error ** 2 + 1))
+        * max_excitation_error
+    )
     return fac
 
 

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -54,8 +54,9 @@ def linear(excitation_error, max_excitation_error):
     -------
     intensities : array-like or float
     """
-
-    return 1 - np.abs(excitation_error) / max_excitation_error
+    sf = 1 - np.abs(excitation_error) / max_excitation_error
+    sf[sf < 0.0] = 0.0
+    return sf
 
 
 def sinc(excitation_error, max_excitation_error, minima_number=5):


### PR DESCRIPTION
**Release Notes**
* In `DiffractionGenerator`, `scattering_params` now takes `None` as an option, which acts to ignore atomic scattering altogether. This emulates the way ASTAR simulates patterns if the `linear` shape function is used.
* Changed the `Lorentzian` shape factor model such that the peak is always at 1.
* I added an extra parameter `shape_factor_width` in `calculate_ed_data` to optionally decouple the "cutting" operation from the shape factor width. If not set it will take the same value as `max_excitation_error`. For linear shape functions it does not make sense to have them be different, but for distributions with wide infinite tails it might (otherwise you "cut" out reflections always at the same value of the shape factor).
* I fixed the linear shape function so that it can not be negative
* When simulating with precession I added a pre-filter using the `max_excitation_error` so that the calculation does not have to be performed on the entire sphere of reciprocal space points. I make the simple assumption that points must lie between or on the cone extremes swept out by the precessing sphere (approximated as a plane). Since `max_excitation_error` and `shape_factor_width` are decoupled, any possible error (incorrectly removed reflections) from a very curved Ewald sphere should be correctable.
* Some docstring clarifications and fixes
* black formatting

**What does this PR do? Please describe and/or link to an open issue.**
See issues #159 and #163. I took another look at the ED simulation procedure and it looks pretty solid. The main point I added is the option to simulate without taking atomic scattering into consideration, which boosts the relative intensity of spots further away from the origin - this should emulate the behavior of how ASTAR simulates patterns. 

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Improve test coverage to consider `scattering_params = None` option
- [ ] Update changelog

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
