### PR TITLE
Minor bugfixes

### DIFF
--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -52,6 +52,7 @@ class DiffractionLibraryGenerator:
         half_shape,
         with_direct_beam=True,
         max_excitation_error=1e-2,
+        shape_factor_width=None,
         debye_waller_factors={},
     ):
         """Calculates a dictionary of diffraction data for a library of crystal
@@ -79,6 +80,9 @@ class DiffractionLibraryGenerator:
         max_excitation_error : float
             The extinction distance for reflections, in reciprocal
             Angstroms.
+        shape_factor_width : float
+            Determines the width of the shape functions of the reflections in
+            Angstroms. If not set is equal to max_excitation_error.
         debye_waller_factors : dict of str:value pairs
             Maps element names to their temperature-dependent Debye-Waller factors.
 
@@ -93,6 +97,8 @@ class DiffractionLibraryGenerator:
         diffraction_library = DiffractionLibrary()
         # The electron diffraction calculator to do simulations
         diffractor = self.electron_diffraction_calculator
+        if shape_factor_width is None:
+            shape_factor_width = max_excitation_error
         # Iterate through phases in library.
         for phase_name in structure_library.struct_lib.keys():
             phase_diffraction_library = dict()
@@ -111,6 +117,7 @@ class DiffractionLibraryGenerator:
                     rotation=orientation,
                     with_direct_beam=with_direct_beam,
                     max_excitation_error=max_excitation_error,
+                    shape_factor_width=shape_factor_width,
                     debye_waller_factors=debye_waller_factors,
                 )
 

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -107,6 +107,15 @@ def test_shape_factor_precession(model):
     r = np.array([1, 5])
     _ = _shape_factor_precession(excitation, r, 0.5, model, 0.1)
 
+
+def test_linear_shape_factor():
+    excitation = np.array([-2, -1, -0.5, 0, 0.5, 1, 2])
+    totest = linear(excitation, 1)
+    np.testing.assert_allclose(totest, np.array([0,0,0.5,1,0.5,0,0]))
+    np.testing.assert_allclose(linear(0.5, 1), 0.5)
+
+
+
 @pytest.mark.parametrize(
     "model, expected",
     [("linear", linear), ("lorentzian", lorentzian), (binary, binary)],

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -38,7 +38,6 @@ def binary(excitation_error, max_excitation_error):
     return 1
 
 
-@np.vectorize
 def linear(excitation_error, max_excitation_error):
     """
     Returns an intensity linearly scaled with by the excitation error
@@ -56,8 +55,10 @@ def linear(excitation_error, max_excitation_error):
     intensities : array-like or float
     """
     sf = 1 - np.abs(excitation_error) / max_excitation_error
-    if sf < 0.:
-        sf = 0.
+    if isinstance(excitation_error, np.ndarray):
+        sf[sf < 0.0] = 0.0
+    else:
+        sf = max(sf, 0.)
     return sf
 
 


### PR DESCRIPTION
---
name: Minor bugfixes
about: Added a kwarg and fixed linear shape function

---

**Release Notes**
The new keyword argument shape factor width was not implemented in the diffraction generator. This is now done so that it can be used when generating a diffraction library.

In addition, I discovered as strange bug that I couldn't pickle the diffraction library when I used the `linear` shape function to calculate it. I traced this back to my use of `np.vectorize` on the `linear` shape function, so I had to alter this function to get it to work. Now it looks less elegant in my opinion because I have to consider the case whereby an array is passed in and when a simple number is passed in (occurs when doing the full precession calculation). If there is a more elegant way to do this let me know.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
