### PR TITLE
Label diffraction spots in plot

### DIFF
--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -43,7 +43,7 @@ from diffsims.generators.sphere_mesh_generators import (
 # https://github.com/pyxem/orix/issues/125#issuecomment-698956290.
 crystal_system_dictionary = {
     "cubic": [(0, 0, 1), (1, 1, 1), (1, 0, 1)],
-    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (-1, 2, -1, 0)],
+    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (2, -1, -1, 0)],
     "trigonal": [(0, 0, 0, 1), (-2, 1, 1, 0), (-1, 2, -1, 0)],
     "tetragonal": [(0, 0, 1), (1, 0, 0), (1, 1, 0)],
     "orthorhombic": [(0, 0, 1), (-1, 0, 0), (0, 1, 0)],

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -218,7 +218,7 @@ class DiffractionSimulation:
 
         return np.divide(pattern, np.max(pattern))
 
-    def plot(self, size_factor=1, units="real", show_labels=False, 
+    def plot(self, size_factor=1, units="real", show_labels=False,
             label_offset=(0, 0),
             label_formatting={},
             ax=None,
@@ -283,6 +283,11 @@ class DiffractionSimulation:
                          (coords[:,1] < max(ylim)))
             millers = millers[condition]
             coords = coords[condition]
+            # default alignment options
+            if "ha" not in label_offset and "horizontalalignment" not in label_formatting:
+                label_formatting["ha"]="center"
+            if "va" not in label_offset and "verticalalignment" not in label_formatting:
+                label_formatting["va"]="center"
             for miller, coordinate in zip(millers, coords):
                 label = "("
                 for index in miller:
@@ -294,7 +299,7 @@ class DiffractionSimulation:
                 label = label[:-1] + ")"
                 ax.text(coordinate[0] + label_offset[0],
                         coordinate[1] + label_offset[1],
-                        label, ha="center", va="center",
+                        label,
                         **label_formatting,
                         )
         return ax, sp

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -127,7 +127,7 @@ class DiffractionSimulation:
 
     def get_as_mask(self, shape, radius=6., negative=True,
                     radius_function=None, direct_beam_position=None,
-                    in_plane_angle=0,
+                    in_plane_angle=0, mirrored=False,
                     *args, **kwargs):
         """
         Return the diffraction pattern as a binary mask of type
@@ -152,6 +152,9 @@ class DiffractionSimulation:
             the center of the image.
         in_plane_angle: float, optional
             In plane rotation of the pattern in degrees
+        mirrored: bool, optional
+            Whether the pattern should be flipped over the x-axis,
+            corresponding to the inverted orientation
         """
         r = radius
         cx, cy = shape[0]//2, shape[1]//2
@@ -160,7 +163,8 @@ class DiffractionSimulation:
         point_coordinates_shifted = self.calibrated_coordinates[:, :-1].copy()
         x = point_coordinates_shifted[:, 0]
         y = point_coordinates_shifted[:, 1]
-        theta = np.arctan2(y, x) + np.deg2rad(in_plane_angle)
+        mirrored_factor = -1 if mirrored else 1
+        theta = mirrored_factor * np.arctan2(y, x) + np.deg2rad(in_plane_angle)
         rd = np.sqrt(x**2 + y**2)
         point_coordinates_shifted[:, 0] = rd * np.cos(theta) + cx
         point_coordinates_shifted[:, 1] = rd * np.sin(theta) + cy

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -186,14 +186,16 @@ class TestDiffractionSimulation:
                                      )
         assert mask.shape[0] == 20
         assert mask.shape[1] == 10
-        
 
     @pytest.mark.parametrize("units_in",['pixel','real'])
     def test_plot_method(self,units_in):
         short_sim = DiffractionSimulation(
-            coordinates=np.asarray([[0.3, 1.2, 0]]),
-            intensities=np.ones(1),
+            coordinates=np.asarray([[0.3, 1.2, 0],
+                                    [2.1, 3.4, 0]]),
+            indices=np.array([[-2, 3, 4],
+                              [ 2,-6, 1],
+                              [ 0, 0, 0]]),
+            intensities=np.array([3., 5.]),
             calibration=[1, 2],
         )
-
-        ax,sp = short_sim.plot(units=units_in)
+        ax, sp = short_sim.plot(units=units_in, show_labels=True)

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -58,7 +58,7 @@ def add_polygon_to_mask(mask, coords, fill=False):
     tempmask = Image.fromarray(mask)
     draw = ImageDraw.Draw(tempmask)
     draw.polygon(coords, fill=fill)
-    mask[:] = np.array(tempmask, dtype=bool)
+    mask[:] = np.array(tempmask).astype(bool)
 
 
 def add_circles_to_mask(mask, coords, r, fill=False):


### PR DESCRIPTION
---
name: Option to add labels in simulation diffraction spots
---

**Release Notes**
> extra parameters in diffraction pattern's `plot` method for drawing miller index labels next to the diffraction spots

**What does this PR do? Please describe and/or link to an open issue.**
After discussion in #170 I thought I would open this small PR for adding the option to draw the miller indices of spot patterns. With this change it is now possible to do the following:

```python
fig, ax = plt.subplots()
ax.set_aspect("equal")
ax.set_xlim(-2, 2)
ax.set_ylim(2, -2)
simtest.plot(show_labels=True, label_offset=(0, -0.2), 
             label_formatting={"fontsize": 8},
             size_factor=10, ax = ax)
```

![afbeelding](https://user-images.githubusercontent.com/25320842/124643805-d039b880-de91-11eb-8c51-31b2d11bd84f.png)

Does this approach what you had in mind @CSSFrancis ?

Apparently there are also two small additions: the option to mirror pattern masks and the update to the stereo triangle for the hex system. It seems this was not merged before, see #168 

**Are there any known issues? Do you need help?**
I would have liked to create a vectorized implementation but have no idea if this is possible with strings. Probably one could do some smart tricks with string formatting, but I couldn't figure out how to do that with the `\bar{}` on negative indices. If anyone has a better implementation idea feel free to modify.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [ ] Needs a test to be added for coverage

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
