### PR TITLE
Improve DiffractionSimulation

### DIFF
--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -20,9 +20,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from diffsims.pattern.detector_functions import add_shot_and_point_spread
 from diffsims.utils import mask_utils
+from collections import Sequence
 
 
-class DiffractionSimulation:
+class DiffractionSimulation(Sequence):
     """Holds the result of a kinematic diffraction pattern simulation.
 
     Parameters
@@ -68,6 +69,21 @@ class DiffractionSimulation:
         self.calibration = calibration
         self.offset = offset
         self.with_direct_beam = with_direct_beam
+
+    def __len__(self):
+        return self.direct_beam_mask.shape[0]
+
+    def __getitem__(self, sliced):
+        coords = self.coordinates[sliced]
+        inds = self.indices[sliced]
+        ints = self.intensities[sliced]
+        return DiffractionSimulation(coords,
+                                     indices=inds,
+                                     intensities=ints,
+                                     calibration=self.calibration,
+                                     offset=self.offset,
+                                     with_direct_beam=self.with_direct_beam
+                                    )
 
     @property
     def indices(self):

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -48,35 +48,45 @@ class DiffractionSimulation(Sequence):
         coordinates,
         indices=None,
         intensities=None,
-        calibration=1.0,
+        calibration=None,
         offset=(0.0, 0.0),
         with_direct_beam=False,
     ):
         """Initializes the DiffractionSimulation object with data values for
         the coordinates, indices, intensities, calibration and offset.
         """
+        if coordinates.ndim == 1:
+            coordinates = coordinates[None,:]
         if indices is None:
-            indices = np.zeros((coordinates.shape[0], 3))
+            indices = np.full((coordinates.shape[0], 3), np.nan)
         if intensities is None:
-            intensities = np.zeros((coordinates.shape[0]))
+            intensities = np.full((coordinates.shape[0]), np.nan)
         # check here whether shapes are all the same
-        if coordinates.shape[0] == indices.shape[0] == intensities.shape[0]:
+        if (coordinates.shape[0] == indices.shape[0] == intensities.shape[0] and
+            coordinates.ndim == indices.ndim == 2 and intensities.ndim==1):
             self._coordinates = coordinates
             self._indices = indices
             self._intensities = intensities
         else:
-            raise ValueError("Coordinate, intensity, and indices lists must be same size.")
+            raise ValueError("Coordinate, intensity, and indices lists must be of the correct and matching shape.")
         self.calibration = calibration
         self.offset = offset
         self.with_direct_beam = with_direct_beam
 
     def __len__(self):
-        return self.direct_beam_mask.shape[0]
+        return self.coordinates.shape[0]
 
     def __getitem__(self, sliced):
         coords = self.coordinates[sliced]
         inds = self.indices[sliced]
         ints = self.intensities[sliced]
+        if coords.ndim == 1:
+            coords = coords[None, :]
+            inds = inds[None, :]
+            ints = ints[None]
+        # some valid numpy slices will create invalid shapes for diffraction simulation
+        if coords.ndim > 2 or coords.shape[1] > 3 or coords.shape[1] < 2:
+            raise ValueError(f"Invalid slice: {sliced}")
         return DiffractionSimulation(coords,
                                      indices=inds,
                                      intensities=ints,
@@ -84,6 +94,29 @@ class DiffractionSimulation(Sequence):
                                      offset=self.offset,
                                      with_direct_beam=self.with_direct_beam
                                     )
+
+    def _combine_data(self, other):
+        coords = np.concatenate([self._coordinates, other._coordinates], axis=0)
+        inds = np.concatenate([self._indices, other._indices], axis=0)
+        ints = np.concatenate([self._intensities, other._intensities], axis=0)
+        return coords, inds, ints
+
+    def __add__(self, other):
+        coords, inds, ints = self._combine_data(other)
+        return DiffractionSimulation(coords,
+                                     indices=inds,
+                                     intensities=ints,
+                                     calibration=self.calibration,
+                                     offset=self.offset,
+                                     with_direct_beam=self.with_direct_beam
+                                    )
+
+    def extend(self, other):
+        """Add the diffraction spots from another DiffractionSimulation"""
+        coords, inds, ints = self._combine_data(other)
+        self._coordinates = coords
+        self._indices = inds
+        self._ints = ints
 
     @property
     def indices(self):
@@ -96,7 +129,10 @@ class DiffractionSimulation(Sequence):
     @property
     def calibrated_coordinates(self):
         """ndarray : Coordinates converted into pixel space."""
-        return (self.coordinates[:, :2] + np.array(self.offset))/np.array(self.calibration)
+        if self.calibration is not None:
+            return (self.coordinates[:, :2] + np.array(self.offset))/np.array(self.calibration)
+        else:
+            raise Exception("Pixel calibration is not set!")
 
     @property
     def calibration(self):
@@ -106,6 +142,9 @@ class DiffractionSimulation(Sequence):
 
     @calibration.setter
     def calibration(self, calibration):
+        if calibration is None:
+            self._calibration = calibration
+            return
         if np.all(np.equal(calibration, 0)):
             raise ValueError("`calibration` cannot be zero.")
         if isinstance(calibration, float) or isinstance(calibration, int):
@@ -145,6 +184,47 @@ class DiffractionSimulation(Sequence):
     def intensities(self, intensities):
         self._intensities[self.direct_beam_mask] = intensities
 
+    def _get_transformed_coordinates(self, angle, center=(0, 0),
+                                     mirrored=False, units="real"):
+        """
+        Get the coordinates of diffraction spots rotated, flipped or shifted
+        in-plane
+
+        Parameters
+        ----------
+        angle: float
+            Angle in degrees
+        center: 2-tuple of floats
+            Center of the patterns
+        mirrored: bool
+            Mirror accross the x axis
+        units: str
+            "real" or "pixel"
+
+        Returns
+        -------
+        coords_transformed: np.ndarray of shape (N, 3) or (N, 2)
+            transformed coordinates
+        """
+        if units == "real":
+            coords_transformed = self.coordinates.copy()
+        else:
+            coords_transformed = self.calibrated_coordinates.copy()
+        cx, cy = center
+        x = coords_transformed[:, 0]
+        y = coords_transformed[:, 1]
+        mirrored_factor = -1 if mirrored else 1
+        theta = mirrored_factor * np.arctan2(y, x) + np.deg2rad(angle)
+        rd = np.sqrt(x**2 + y**2)
+        coords_transformed[:, 0] = rd * np.cos(theta) + cx
+        coords_transformed[:, 1] = rd * np.sin(theta) + cy
+        return coords_transformed
+
+    def rotate_shift_coordinates(self, angle, center=(0, 0), mirrored=False):
+        """Translate, rotate or mirror the pattern"""
+        coords_new = self._get_transformed_coordinates(angle, center, mirrored, units="real")
+        self.coordinates = coords_new
+
     def get_as_mask(self, shape, radius=6., negative=True,
                     radius_function=None, direct_beam_position=None,
                     in_plane_angle=0, mirrored=False,
@@ -175,19 +255,18 @@ class DiffractionSimulation(Sequence):
         mirrored: bool, optional
             Whether the pattern should be flipped over the x-axis,
             corresponding to the inverted orientation
+
+        Returns
+        -------
+        mask: numpy.ndarray
+            Boolean mask of the diffraction pattern
         """
         r = radius
-        cx, cy = shape[0]//2, shape[1]//2
+        cx, cy = shape[1]//2, shape[0]//2
         if direct_beam_position is not None:
             cx, cy = direct_beam_position
-        point_coordinates_shifted = self.calibrated_coordinates.copy()
-        x = point_coordinates_shifted[:, 0]
-        y = point_coordinates_shifted[:, 1]
-        mirrored_factor = -1 if mirrored else 1
-        theta = mirrored_factor * np.arctan2(y, x) + np.deg2rad(in_plane_angle)
-        rd = np.sqrt(x**2 + y**2)
-        point_coordinates_shifted[:, 0] = rd * np.cos(theta) + cx
-        point_coordinates_shifted[:, 1] = rd * np.sin(theta) + cy
+        point_coordinates_shifted = self._get_transformed_coordinates(
+                in_plane_angle, center=(cx, cy), mirrored=mirrored, units="pixels")
         if radius_function is not None:
             r = radius_function(self.intensities, *args, **kwargs)
         mask = mask_utils.create_mask(shape, fill=negative)
@@ -195,18 +274,27 @@ class DiffractionSimulation(Sequence):
                                     fill=not negative)
         return mask
 
-    def get_diffraction_pattern(self, size=512, sigma=10):
+    def get_diffraction_pattern(self, shape=(512, 512), sigma=10,
+                                direct_beam_position=None, in_plane_angle=0,
+                                mirrored=False):
         """Returns the diffraction data as a numpy array with
         two-dimensional Gaussians representing each diffracted peak. Should only
         be used for qualitative work.
 
         Parameters
         ----------
-        size  : int
+        shape  : tuple of ints
             The size of a side length (in pixels)
-
         sigma : float
             Standard deviation of the Gaussian function to be plotted (in pixels).
+        direct_beam_position: 2-tuple of ints, optional
+            The (x,y) coordinate in pixels of the direct beam. Defaults to
+            the center of the image.
+        in_plane_angle: float, optional
+            In plane rotation of the pattern in degrees
+        mirrored: bool, optional
+            Whether the pattern should be flipped over the x-axis,
+            corresponding to the inverted orientation
 
         Returns
         -------
@@ -219,26 +307,29 @@ class DiffractionSimulation(Sequence):
         produces reasonably good patterns when the lattice parameters are on
         the order of 0.5nm and a the default size and sigma are used.
         """
-        side_length = np.min(np.multiply((size / 2), self.calibration))
-        mask_for_sides = np.all(
-            (np.abs(self.coordinates[:, 0:2]) < side_length), axis=1
-        )
-
-        spot_coords = np.add(
-            self.calibrated_coordinates[mask_for_sides], size / 2
-        ).astype(int)
-        spot_intens = self.intensities[mask_for_sides]
-        pattern = np.zeros([size, size])
+        cx, cy = shape[1]//2, shape[0]//2
+        if direct_beam_position is not None:
+            cx, cy = direct_beam_position
+        coordinates = self._get_transformed_coordinates(in_plane_angle, (cx, cy), mirrored, units="pixel")
+        in_frame = ((coordinates[:, 0] >= 0) & (coordinates[:, 0] < shape[1]) &
+                    (coordinates[:, 1] >= 0) & (coordinates[:, 1] < shape[0]))
+        spot_coords = coordinates[in_frame].astype(int)
+        spot_intens = self.intensities[in_frame]
+        pattern = np.zeros(shape)
         # checks that we have some spots
         if spot_intens.shape[0] == 0:
             return pattern
         else:
             pattern[spot_coords[:, 0], spot_coords[:, 1]] = spot_intens
             pattern = add_shot_and_point_spread(pattern.T, sigma, shot_noise=False)
-
         return np.divide(pattern, np.max(pattern))
 
-    def plot(self, size_factor=1, units="real", show_labels=False,
+    def plot(self, size_factor=1,
+            direct_beam_position=None,
+            in_plane_angle=0,
+            mirrored=False,
+            units="real",
+            show_labels=False,
             label_offset=(0, 0),
             label_formatting={},
             ax=None,
@@ -249,6 +340,14 @@ class DiffractionSimulation(Sequence):
         ----------
         size_factor : float, optional
             linear spot size scaling, default to 1
+        direct_beam_position: 2-tuple of ints, optional
+            The (x,y) coordinate in pixels of the direct beam. Defaults to
+            the center of the image.
+        in_plane_angle: float, optional
+            In plane rotation of the pattern in degrees
+        mirrored: bool, optional
+            Whether the pattern should be flipped over the x-axis,
+            corresponding to the inverted orientation
         units : str, optional
             'real' or 'pixel', only changes scalebars, falls back on 'real', the default
         show_labels : bool, optional
@@ -272,14 +371,13 @@ class DiffractionSimulation(Sequence):
         -----
         spot size scales with the square root of the intensity.
         """
+        cx, cy = 0, 0
+        if direct_beam_position is not None:
+            cx, cy = direct_beam_position
         if ax is None:
             _, ax = plt.subplots()
             ax.set_aspect("equal")
-        if units == "pixel":
-            coords = self.calibrated_coordinates
-        else:
-            coords = self.coordinates
-
+        coords = self._get_transformed_coordinates(in_plane_angle, (cx, cy), mirrored, units=units)
         sp = ax.scatter(
             coords[:, 0],
             coords[:, 1],

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -262,11 +262,10 @@ class DiffractionSimulation(Sequence):
             Boolean mask of the diffraction pattern
         """
         r = radius
-        cx, cy = shape[1]//2, shape[0]//2
-        if direct_beam_position is not None:
-            cx, cy = direct_beam_position
+        if direct_beam_position is None:
+            direct_beam_position = (shape[1]//2, shape[0]//2)
         point_coordinates_shifted = self._get_transformed_coordinates(
-                in_plane_angle, center=(cx, cy), mirrored=mirrored, units="pixels")
+                in_plane_angle, center=direct_beam_position, mirrored=mirrored, units="pixels")
         if radius_function is not None:
             r = radius_function(self.intensities, *args, **kwargs)
         mask = mask_utils.create_mask(shape, fill=negative)
@@ -307,10 +306,9 @@ class DiffractionSimulation(Sequence):
         produces reasonably good patterns when the lattice parameters are on
         the order of 0.5nm and a the default size and sigma are used.
         """
-        cx, cy = shape[1]//2, shape[0]//2
-        if direct_beam_position is not None:
-            cx, cy = direct_beam_position
-        coordinates = self._get_transformed_coordinates(in_plane_angle, (cx, cy), mirrored, units="pixel")
+        if direct_beam_position is None:
+            direct_beam_position = (shape[1]//2, shape[0]//2)
+        coordinates = self._get_transformed_coordinates(in_plane_angle, direct_beam_position, mirrored, units="pixel")
         in_frame = ((coordinates[:, 0] >= 0) & (coordinates[:, 0] < shape[1]) &
                     (coordinates[:, 1] >= 0) & (coordinates[:, 1] < shape[0]))
         spot_coords = coordinates[in_frame].astype(int)
@@ -371,13 +369,12 @@ class DiffractionSimulation(Sequence):
         -----
         spot size scales with the square root of the intensity.
         """
-        cx, cy = 0, 0
-        if direct_beam_position is not None:
-            cx, cy = direct_beam_position
+        if direct_beam_position is None:
+            direct_beam_position = (0, 0)
         if ax is None:
             _, ax = plt.subplots()
             ax.set_aspect("equal")
-        coords = self._get_transformed_coordinates(in_plane_angle, (cx, cy), mirrored, units=units)
+        coords = self._get_transformed_coordinates(in_plane_angle, direct_beam_position, mirrored, units=units)
         sp = ax.scatter(
             coords[:, 0],
             coords[:, 1],

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -22,13 +22,13 @@ from diffsims.sims.diffraction_simulation import DiffractionSimulation
 from diffsims.sims.diffraction_simulation import ProfileSimulation
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_wrong_calibration_setting():
-    DiffractionSimulation(
-        coordinates=np.asarray([[0.3, 1.2, 0]]),
-        intensities=np.ones(1),
-        calibration=[1, 2, 5],
-    )
+    with pytest.raises(ValueError, match="must be a float"):
+        DiffractionSimulation(
+            coordinates=np.asarray([[0.3, 1.2, 0]]),
+            intensities=np.ones(1),
+            calibration=[1, 2, 5],
+        )
 
 
 @pytest.fixture
@@ -96,11 +96,11 @@ class TestDiffractionSimulation:
             np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), calibration=0.5
         )
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_failed_initialization(self):
-        DiffractionSimulation(
-            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3])
-        )
+        with pytest.raises(ValueError, match="Coordinate"):
+            DiffractionSimulation(
+                np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3])
+            )
 
     def test_init(self, diffraction_simulation):
         assert np.allclose(
@@ -120,9 +120,9 @@ class TestDiffractionSimulation:
         assert diffraction_simulation[1].coordinates.shape == (1, 3)
         assert diffraction_simulation[0:2].coordinates.shape == (2, 3)
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_fail_get_item(self, diffraction_simulation):
-        diffraction_simulation[None]
+        with pytest.raises(ValueError, match="Invalid"):
+            _ = diffraction_simulation[None]
 
     def test_addition(self, diffraction_simulation):
         sim = diffraction_simulation + diffraction_simulation
@@ -179,16 +179,16 @@ class TestDiffractionSimulation:
     @pytest.mark.parametrize(
         "calibration, expected",
         [
-            (5.0, (5.0, 5.0)),
+            (5.0, np.array((5.0, 5.0))),
             pytest.param(0, (0, 0), marks=pytest.mark.xfail(raises=ValueError)),
             pytest.param((0, 0), (0, 0), marks=pytest.mark.xfail(raises=ValueError)),
-            ((1.5, 1.5), (1.5, 1.5)),
-            ((1.3, 1.5), (1.3, 1.5)),
+            ((1.5, 1.5), np.array((1.5, 1.5))),
+            ((1.3, 1.5), np.array((1.3, 1.5))),
         ],
     )
     def test_calibration(self, diffraction_simulation, calibration, expected):
         diffraction_simulation.calibration = calibration
-        assert diffraction_simulation.calibration == expected
+        assert np.allclose(diffraction_simulation.calibration, expected)
 
     @pytest.mark.parametrize(
         "coordinates, with_direct_beam, expected",

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -95,7 +95,7 @@ class TestDiffractionSimulation:
         return DiffractionSimulation(np.array([[0, 0, 0],[1, 2, 3], [3, 4, 5]]), calibration=0.5)
 
     @pytest.mark.xfail(raises=ValueError)
-    def failed_initialization(self):
+    def test_failed_initialization(self):
         DiffractionSimulation(np.array([[0, 0, 0],[1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3]))
 
     def test_init(self, diffraction_simulation):
@@ -107,12 +107,15 @@ class TestDiffractionSimulation:
         assert diffraction_simulation.calibration is None
         assert len(diffraction_simulation) == 2
 
-    def get_get_item(self, diffraction_simulation):
+    def test_single_spot(self):
+        assert DiffractionSimulation(np.array([1, 2, 3])).coordinates.shape == (1, 3)
+
+    def test_get_item(self, diffraction_simulation):
         assert diffraction_simulation[1].coordinates.shape == (1, 3)
-        assert diffraction_simulation[1:3].coordinates.shape == (2, 3)
+        assert diffraction_simulation[0:2].coordinates.shape == (2, 3)
 
     @pytest.mark.xfail(raises=ValueError)
-    def fail_get_item(self, diffraction_simulation):
+    def test_fail_get_item(self, diffraction_simulation):
         diffraction_simulation[None]
 
     def test_addition(self, diffraction_simulation):
@@ -147,6 +150,14 @@ class TestDiffractionSimulation:
         diffraction_simulation.with_direct_beam = True
         diffraction_simulation.coordinates = coords
         assert np.allclose(diffraction_simulation.coordinates, coords)
+
+    def test_intensities_setter(self, diffraction_simulation):
+        ints = np.array([1, 2, 3])
+        diffraction_simulation.intensities = ints[-1]
+        assert np.allclose(diffraction_simulation.intensities, ints[-1])
+        diffraction_simulation.with_direct_beam = True
+        diffraction_simulation.intensities = ints
+        assert np.allclose(diffraction_simulation.intensities, ints)
 
     @pytest.mark.parametrize(
         "calibration, expected",
@@ -263,7 +274,6 @@ class TestDiffractionSimulation:
         )
         mask = short_sim.get_as_mask((20, 10),
                                      radius_function=np.sqrt,
-                                     direct_beam_position=(10, 6)
                                      )
         assert mask.shape[0] == 20
         assert mask.shape[1] == 10

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -88,18 +88,24 @@ def test_plot_profile_simulation(profile_simulation):
 class TestDiffractionSimulation:
     @pytest.fixture
     def diffraction_simulation(self):
-        return DiffractionSimulation(np.array([[0, 0, 0],[1, 2, 3], [3, 4, 5]]))
+        return DiffractionSimulation(np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]))
 
     @pytest.fixture
     def diffraction_simulation_calibrated(self):
-        return DiffractionSimulation(np.array([[0, 0, 0],[1, 2, 3], [3, 4, 5]]), calibration=0.5)
+        return DiffractionSimulation(
+            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), calibration=0.5
+        )
 
     @pytest.mark.xfail(raises=ValueError)
     def test_failed_initialization(self):
-        DiffractionSimulation(np.array([[0, 0, 0],[1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3]))
+        DiffractionSimulation(
+            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3])
+        )
 
     def test_init(self, diffraction_simulation):
-        assert np.allclose(diffraction_simulation.coordinates, np.array([[1, 2, 3], [3, 4, 5]]))
+        assert np.allclose(
+            diffraction_simulation.coordinates, np.array([[1, 2, 3], [3, 4, 5]])
+        )
         assert np.isnan(diffraction_simulation.indices).all()
         assert diffraction_simulation.indices.shape == (2, 3)
         assert np.isnan(diffraction_simulation.intensities).all()
@@ -120,23 +126,34 @@ class TestDiffractionSimulation:
 
     def test_addition(self, diffraction_simulation):
         sim = diffraction_simulation + diffraction_simulation
-        assert np.allclose(sim.coordinates, np.array([[1, 2, 3],
-                                                      [3, 4, 5],
-                                                      [1, 2, 3],
-                                                      [3, 4, 5],
-                                                      ]))
+        assert np.allclose(
+            sim.coordinates,
+            np.array(
+                [
+                    [1, 2, 3],
+                    [3, 4, 5],
+                    [1, 2, 3],
+                    [3, 4, 5],
+                ]
+            ),
+        )
 
     def test_extend(self, diffraction_simulation):
         diffraction_simulation.extend(diffraction_simulation)
-        assert np.allclose(diffraction_simulation.coordinates, np.array([
-                                                      [1, 2, 3],
-                                                      [3, 4, 5],
-                                                      [1, 2, 3],
-                                                      [3, 4, 5],
-                                                      ]))
+        assert np.allclose(
+            diffraction_simulation.coordinates,
+            np.array(
+                [
+                    [1, 2, 3],
+                    [3, 4, 5],
+                    [1, 2, 3],
+                    [3, 4, 5],
+                ]
+            ),
+        )
 
     def test_indices_setter_getter(self, diffraction_simulation):
-        indices = np.array([[1, 2, 3],[2, 3,4],[3, 4, 5]])
+        indices = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
         diffraction_simulation.indices = indices[-1]
         assert np.allclose(diffraction_simulation.indices, indices[-1])
         diffraction_simulation.with_direct_beam = True
@@ -144,7 +161,7 @@ class TestDiffractionSimulation:
         assert np.allclose(diffraction_simulation.indices, indices)
 
     def test_coordinates_setter(self, diffraction_simulation):
-        coords = np.array([[1, 2, 3],[2, 3,4],[3, 4, 5]])
+        coords = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
         diffraction_simulation.coordinates = coords[-1]
         assert np.allclose(diffraction_simulation.coordinates, coords[-1])
         diffraction_simulation.with_direct_beam = True
@@ -189,11 +206,10 @@ class TestDiffractionSimulation:
             (np.array([[-1, 0, 0], [1, 0, 0]]), False, np.array([True, True])),
         ],
     )
-    def test_direct_beam_mask(
-        self, coordinates, with_direct_beam, expected
-    ):
-        diffraction_simulation = DiffractionSimulation(coordinates,
-                                                       with_direct_beam=with_direct_beam)
+    def test_direct_beam_mask(self, coordinates, with_direct_beam, expected):
+        diffraction_simulation = DiffractionSimulation(
+            coordinates, with_direct_beam=with_direct_beam
+        )
         diffraction_simulation.with_direct_beam = with_direct_beam
         mask = diffraction_simulation.direct_beam_mask
         assert np.all(mask == expected)
@@ -218,7 +234,7 @@ class TestDiffractionSimulation:
                 None,
                 (0.0, 0.0),
                 None,
-                marks=pytest.mark.xfail(raises=Exception)
+                marks=pytest.mark.xfail(raises=Exception),
             ),
         ],
     )
@@ -232,24 +248,28 @@ class TestDiffractionSimulation:
         diffraction_simulation = DiffractionSimulation(coordinates)
         diffraction_simulation.calibration = calibration
         diffraction_simulation.offset = offset
-        assert np.allclose(diffraction_simulation.calibrated_coordinates,
-                           expected)
+        assert np.allclose(diffraction_simulation.calibrated_coordinates, expected)
 
     @pytest.mark.parametrize(
         "units, expected",
         [
-            ("real", np.array([[-2,1,3],[-4,3,5]])),
-            ("pixel", np.array([[-4,2],[-8,6]])),
+            ("real", np.array([[-2, 1, 3], [-4, 3, 5]])),
+            ("pixel", np.array([[-4, 2], [-8, 6]])),
         ],
     )
-    def test_transform_coordinates(self, diffraction_simulation_calibrated, units, expected):
-        tc = diffraction_simulation_calibrated._get_transformed_coordinates(90, units=units)
+    def test_transform_coordinates(
+        self, diffraction_simulation_calibrated, units, expected
+    ):
+        tc = diffraction_simulation_calibrated._get_transformed_coordinates(
+            90, units=units
+        )
         assert np.allclose(tc, expected)
 
     def test_rotate_shift_coordinates(self, diffraction_simulation):
         diffraction_simulation.rotate_shift_coordinates(90)
-        assert np.allclose(diffraction_simulation.coordinates,
-                           np.array([[-2,1,3],[-4,3,5]]))
+        assert np.allclose(
+            diffraction_simulation.coordinates, np.array([[-2, 1, 3], [-4, 3, 5]])
+        )
 
     def test_assertion_free_get_diffraction_pattern(self):
         short_sim = DiffractionSimulation(
@@ -272,22 +292,25 @@ class TestDiffractionSimulation:
             intensities=np.ones(1),
             calibration=[1, 2],
         )
-        mask = short_sim.get_as_mask((20, 10),
-                                     radius_function=np.sqrt,
-                                     )
+        mask = short_sim.get_as_mask(
+            (20, 10),
+            radius_function=np.sqrt,
+        )
         assert mask.shape[0] == 20
         assert mask.shape[1] == 10
 
-    @pytest.mark.parametrize("units_in",['pixel','real'])
-    def test_plot_method(self,units_in):
+    @pytest.mark.parametrize("units_in", ["pixel", "real"])
+    def test_plot_method(self, units_in):
         short_sim = DiffractionSimulation(
-            coordinates=np.asarray([[0.3, 1.2, 0],
-                                    [-2, 3, 0],
-                                    [2.1, 3.4, 0],]),
-            indices=np.array([[-2, 3, 4],
-                              [ 2,-6, 1],
-                              [ 0, 0, 0]]),
-            intensities=np.array([3., 5., 2.]),
+            coordinates=np.asarray(
+                [
+                    [0.3, 1.2, 0],
+                    [-2, 3, 0],
+                    [2.1, 3.4, 0],
+                ]
+            ),
+            indices=np.array([[-2, 3, 4], [2, -6, 1], [0, 0, 0]]),
+            intensities=np.array([3.0, 5.0, 2.0]),
             calibration=[1, 2],
         )
         ax, sp = short_sim.plot(units=units_in, show_labels=True)


### PR DESCRIPTION
---
name: Fix DiffractionSimulation
about: see #174

---

**Release Notes**
Reworked the way `DiffractionSimulation` behaves, thereby fixing issues setting properties like `coordinates`, `indices` and `intensities`. 

**What does this PR do? Please describe and/or link to an open issue.**
This PR aims to fix #174 but also reworks the class a bit

The changes mainly pertain to the property/setter behavior of the `coordinates`, `indices` and `intensities` attributes. Previously `DiffractionSimulation` could exist as an empty shell without any diffraction spots, and coordinates, indices and intensities could be set to anything. This can cause all kinds of issues with the getters, that relied on `_coordinates`, etc. to be either all arrays of the same size or `None`. But this was not enforced anywhere, plus one ran into trouble with the `with_direct_beam` masking.

I have changed `coordinates` to a mandatory argument in the `__init__`.  My reasoning is that a diffraction pattern without any spots doesn't make much sense. A completely empty array can still be passed. Indices and intensities can be left empty but appropriately sized arrays of zeros will be automatically created based on the size of `coordinates`. In the `init` method, the shape of all these arrays is verified, and `_coordinates`, `_indices` and `_intensities` are set based on what is passed in. The getters and setters of `indices` `intensities` and `coordinates` can then be substantially simplified, both rely on `self.direct_beam_mask` and stay consistent in shape amongst each other since I use numpy slicing to update the values. Changing the number of spots is no longer allowed, for this one should simply create a new `DiffractionSimulation`. What can be done instead now is slicing into the pattern, for example

```
sim[sim.intensities > 8]
```

in order to filter out spots based on some condition. This makes sense as long as `coordinates`, `indices`, and `intensities` are the same size. **note that on a slice like this, information about the direct beam is lost if it was already "filtered out" by `with_direct_beam`**

Other changes I've made were mainly as a consequence of the previous changes and also make sense in my opinion. `calibrated_coordinates` only makes sense in the x-y plane, there is no reason it should return the z-coordinate since there is no calibration value for it. One might consider renaming this `detector_coordinates`?

### 30/09/21
I have tried to clean up this class a bit more and add a couple more features:
- allow for "adding" and "extending" patterns with other patterns, effectively concatenating coordinate, index and intensity arrays. Basically
```
sim1 + sim2
```
Will produce another `DiffractionSimulation` object with the combined spots of the original two. With the `extend` method, spots can be added from another pattern in-place, just like it exists in ASE.
- added rotation, mirroring and translation arguments for plotting, creating a mask and creating a gaussian image of the pattern. It is convenient to be able to rotate, flip and shift the templates easily. I also added a method to rotate, shift, mirror the template spot coordinates in-place.
- The method for creating a diffraction pattern image was reworked to allow for non-square images
- After the issue in #176 , I think it is unreasonable to set calibration to 1 by default. Instead I set it to none by default and whenever a user tries to access `calibrated_coordinates` or a method that depends on it, an exception is raised telling the user the calibration should be set.

**Describe alternatives you've considered**

**Are there any known issues? Do you need help?**

**Work in progress?**
- [x] add testing for __getitem__
- [ ] update changelog

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      the unreleased section in `CHANGELOG.md`.
