### PR TITLE
Update year in license to 2017-2022

### DIFF
--- a/diffsims/__init__.py
+++ b/diffsims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/__init__.py
+++ b/diffsims/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/__init__.py
+++ b/diffsims/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/zap_map_generator.py
+++ b/diffsims/generators/zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/__init__.py
+++ b/diffsims/libraries/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/diffraction_library.py
+++ b/diffsims/libraries/diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/vector_library.py
+++ b/diffsims/libraries/vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/__init__.py
+++ b/diffsims/pattern/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/sims/__init__.py
+++ b/diffsims/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/__init__.py
+++ b/diffsims/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_factor.py
+++ b/diffsims/structure_factor/atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/structure_factor.py
+++ b/diffsims/structure_factor/structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/__init__.py
+++ b/diffsims/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/conftest.py
+++ b/diffsims/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/__init__.py
+++ b/diffsims/tests/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_reciprocal_lattice_point.py
+++ b/diffsims/tests/crystallography/test_reciprocal_lattice_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/__init__.py
+++ b/diffsims/tests/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_library_generator.py
+++ b/diffsims/tests/generators/test_library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/generators/test_sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_zap_map_generator.py
+++ b/diffsims/tests/generators/test_zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/__init__.py
+++ b/diffsims/tests/library/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_diffraction_library.py
+++ b/diffsims/tests/library/test_diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_structure_library.py
+++ b/diffsims/tests/library/test_structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_vector_library.py
+++ b/diffsims/tests/library/test_vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/__init__.py
+++ b/diffsims/tests/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/__init__.py
+++ b/diffsims/tests/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_parameter.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_parameter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_structure_factor.py
+++ b/diffsims/tests/structure_factor/test_structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/__init__.py
+++ b/diffsims/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
+++ b/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_discretise_utils.py
+++ b/diffsims/tests/utils/test_discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_fourier_transform.py
+++ b/diffsims/tests/utils/test_fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_generic_utils.py
+++ b/diffsims/tests/utils/test_generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_kinematic_simulation_utils.py
+++ b/diffsims/tests/utils/test_kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_mask_utils.py
+++ b/diffsims/tests/utils/test_mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_probe_utils.py
+++ b/diffsims/tests/utils/test_probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_ring_pattern_utils.py
+++ b/diffsims/tests/utils/test_ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_vector_utils.py
+++ b/diffsims/tests/utils/test_vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/__init__.py
+++ b/diffsims/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_diffraction_generator_utils.py
+++ b/diffsims/utils/atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_scattering_params.py
+++ b/diffsims/utils/atomic_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/fourier_transform.py
+++ b/diffsims/utils/fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/generic_utils.py
+++ b/diffsims/utils/generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/kinematic_simulation_utils.py
+++ b/diffsims/utils/kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/lobato_scattering_params.py
+++ b/diffsims/utils/lobato_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/probe_utils.py
+++ b/diffsims/utils/probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/ring_pattern_utils.py
+++ b/diffsims/utils/ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/scattering_params.py
+++ b/diffsims/utils/scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/vector_utils.py
+++ b/diffsims/utils/vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2022 The diffsims developers
 #
 # This file is part of diffsims.
 #


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Update year in license to 2017-2022 using `licenseheaders -y 2017-2022` in the `diffsims/` directory.