### PR TITLE
State Python 3.10 support, harmonize minimal versions in setup/CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         run: python setup.py manifix
 
   build-with-pip:
-    name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9, '3.10']
         include:
           # Oldest supported version of main dependencies on Python 3.6
           - os: ubuntu-latest
@@ -33,15 +33,15 @@ jobs:
             OLDEST_SUPPORTED_VERSION: true
             # orix requires matplotlib 3.3, matplotlib 3.3 requires numpy 1.15
             # numba requires scipy==1.0
-            # scipy==0.15 throws ufunc error
             DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.5.0 scipy==1.0 tqdm==4.9
+            LABEL: -oldest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Display versions
+      - name: Display Python and pip versions
         run: python -V; pip -V
       - name: Install depedencies and package
         shell: bash
@@ -49,6 +49,8 @@ jobs:
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: pip install ${{ matrix.DEPENDENCIES }}
+      - name: Display package versions
+        run: pip list
       - name: Run tests
         run: pytest --cov=diffsims --pyargs diffsims
       - name: Generate line coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 - Extra parameters in diffraction pattern's plot method for drawing miller index labels
   next to the diffraction spots
 - Option to use None for `scattering_params` which ignores atomic scattering
+- Python 3.10 support.
 
 Changed
 -------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,7 +10,7 @@ We recommend you install it in a `conda environment
 <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
 with the `Miniconda distribution`_::
 
-   conda create --name diffsims-env python=3.9
+   conda create --name diffsims-env python=3.10
    conda activate diffsims-env
 
 If you prefer a graphical interface to manage packages and environments, install the

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -59,12 +60,12 @@ setup(
     extras_require=extra_feature_requirements,
     install_requires=[
         "diffpy.structure   >= 3.0.0",  # First Python 3 support
-        "matplotlib         >= 3.1.1",
+        "matplotlib         >= 3.3",
         "numba",
         "numpy              >= 1.17",
         "orix               >= 0.5.0",
         "psutil",
-        "scipy              >= 0.15",
+        "scipy              >= 1.0",
         "tqdm               >= 4.9",
         "transforms3d",
     ],


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* State Python 3.10 support
* Harmonize minimal versions in setup.py and CI

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
