### PR TITLE
Minor preparations for a 0.5 release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,5 @@
 - [ ] New functions are imported in corresponding `__init__.py`.
 - [ ] New features, API changes, and deprecations are mentioned in the
       unreleased section in `CHANGELOG.rst`.
+- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
+      in `.zenodo.json`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
+
       - name: Install dependencies
         run: pip install manifix
+
       - name: Check MANIFEST.in file
         run: python setup.py manifix
 
@@ -31,31 +34,39 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.6
             OLDEST_SUPPORTED_VERSION: true
-            # orix requires matplotlib 3.3, matplotlib 3.3 requires numpy 1.15
-            # numba requires scipy==1.0
             DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.5.0 scipy==1.0 tqdm==4.9
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Display Python and pip versions
-        run: python -V; pip -V
-      - name: Install depedencies and package
+        run: |
+          python -V
+          pip -V
+
+      - name: Install dependencies and package
         shell: bash
         run: pip install -U -e .'[tests]'
+
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: pip install ${{ matrix.DEPENDENCIES }}
+
       - name: Display package versions
         run: pip list
+
       - name: Run tests
         run: pytest --cov=diffsims --pyargs diffsims
+
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: coverage report --show-missing
+
       - name: Upload coverage to Coveralls
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,31 +1,49 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow runs when a tagged release is created or it is triggered manually.
+# For more information see:
+# - Python docs: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# - GitHub action: https://github.com/marketplace/actions/pypi-publish
+# - GitHub docs: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+# The source distribution (sdist) is built with the `build` package
+# (https://pypa-build.readthedocs.io/en/stable/index.html).
+# The sdist is attempted uploaded to TestPyPI and PyPI whenever the workflow is run
 
-name: Upload Python Package
+name: Upload to PyPI
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    workflow: "*"
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        pip install build
+
+    - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python -m build
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,65 @@
+{
+  "creators": [
+    {
+      "name": "Duncan Johnstone"
+    },
+    {
+      "name":"Phillip Crout",
+      "orcid": "0000-0001-5754-0938"
+    },
+    {
+      "name":"Håkon Wiik Ånes",
+      "orcid": "0000-0002-1213-2911",
+      "affiliation": "Norwegian University of Science and Technology"
+    },
+    {
+      "name":"Eric Prestat"
+    },
+    {
+      "name":"Rob Tovey"
+    },
+    {
+      "name":"Simon Høgås"
+    },
+    {
+      "name":"Ben Martineau"
+    },
+    {
+      "name":"Joonatan Laulainen"
+    },
+    {
+      "name":"Niels Cautaerts",
+      "orcid": "0000-0002-6402-9879"
+    },
+    {
+      "name":"Isabel Wood"
+    },
+    {
+      "name":"Sean Collins"
+    },
+    {
+      "name":"Stef Smeets"
+    },
+    {
+      "name":"Alex Borrelli"
+    },
+    {
+      "name": "Tiarnan Doherty"
+    },
+    {
+      "name":"Jedrzej Morzy"
+    },
+    {
+      "name":"Endre Jacobsen"
+    },
+    {
+      "name":"Tina Bergh"
+    },
+    {
+      "name":"Tomas Ostasevicius"
+    },
+    {
+      "name":"Eirik Opheim"
+    }
+  ]
+}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-05-25 - version 0.5.0
+2022-05-30 - version 0.5.0
 ==========================
 
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
-==========
+2022-05-20 - version 0.5.0
+==========================
 
 Added
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-05-20 - version 0.5.0
+2022-05-25 - version 0.5.0
 ==========================
 
 Added
@@ -20,7 +20,7 @@ Added
 
 Changed
 -------
-- Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9
+- Minimal version of dependencies orix >= 0.9, numpy >= 1.17 and tqdm >= 4.9
 
 2021-04-16 - version 0.4.2
 ==========================

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -29,7 +29,7 @@ from diffsims.structure_factor.structure_factor import (
 )
 
 
-_FLOAT_EPS = np.finfo(np.float).eps  # Used to round values below 1e-16 to zero
+_FLOAT_EPS = np.finfo(float).eps  # Used to round values below 1e-16 to zero
 
 
 class ReciprocalLatticePoint:

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -22,9 +22,9 @@ Provides users with a range of gridding functions
 
 import numpy as np
 
-from orix.quaternion import Rotation
-from orix.sampling import get_sample_fundamental, get_sample_local
-from orix.vector import AxAngle
+from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
+from orix.quaternion.rotation import Rotation
+from orix.vector.neo_euler import AxAngle
 
 from diffsims.utils.sim_utils import uvtw_to_uvw
 from diffsims.generators.sphere_mesh_generators import (
@@ -43,8 +43,7 @@ from diffsims.generators.sphere_mesh_generators import (
 # https://github.com/pyxem/orix/issues/125#issuecomment-698956290.
 crystal_system_dictionary = {
     "cubic": [(0, 0, 1), (1, 1, 1), (1, 0, 1)],
-#    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (2, -1, -1, 0)],
-    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (-1, 2, -1, 0)],
+    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (2, -1, -1, 0)],
     "trigonal": [(0, 0, 0, 1), (-2, 1, 1, 0), (-1, 2, -1, 0)],
     "tetragonal": [(0, 0, 1), (1, 0, 0), (1, 1, 0)],
     "orthorhombic": [(0, 0, 1), (-1, 0, 0), (0, 1, 0)],
@@ -80,7 +79,7 @@ def get_list_from_orix(grid, rounding=2):
     return rotation_list
 
 
-def get_fundamental_zone_grid(resolution=2, space_group=None):
+def get_fundamental_zone_grid(resolution=2, point_group=None, space_group=None):
     """
     Generates an equispaced grid of rotations within a fundamental zone.
 
@@ -88,6 +87,8 @@ def get_fundamental_zone_grid(resolution=2, space_group=None):
     ----------
     resolution : float, optional
         The characteristic distance between a rotation and its neighbour (degrees)
+    point_group : orix.quaternion.symmetry.Symmetry, optional
+        One of the 11 proper point groups, defaults to None
     space_group: int, optional
         Between 1 and 231, defaults to None
 
@@ -98,7 +99,7 @@ def get_fundamental_zone_grid(resolution=2, space_group=None):
     """
 
     orix_grid = get_sample_fundamental(resolution=resolution, space_group=space_group)
-    rotation_list = get_list_from_orix(orix_grid)
+    rotation_list = get_list_from_orix(orix_grid, rounding=2)
     return rotation_list
 
 
@@ -126,7 +127,7 @@ def get_local_grid(resolution=2, center=None, grid_width=10):
     orix_grid = get_sample_local(
         resolution=resolution, center=center, grid_width=grid_width
     )
-    rotation_list = get_list_from_orix(orix_grid)
+    rotation_list = get_list_from_orix(orix_grid, rounding=2)
     return rotation_list
 
 
@@ -165,7 +166,7 @@ def get_grid_around_beam_direction(beam_rotation, resolution, angular_range=(0, 
     in_plane_rotation = Rotation.from_neo_euler(AxAngle.from_axes_angles(axes, angles))
 
     orix_grid = beam_rotation * in_plane_rotation
-    rotation_list = get_list_from_orix(orix_grid)
+    rotation_list = get_list_from_orix(orix_grid, rounding=2)
     return rotation_list
 
 
@@ -178,15 +179,15 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_e
     Parameters
     ----------
     crystal_system : str
-        Allowed are: 'cubic', 'hexagonal', 'trigonal', 'tetragonal',
-        'orthorhombic', 'monoclinic', 'triclinic'.
+        Allowed are: 'cubic','hexagonal','trigonal','tetragonal',
+        'orthorhombic','monoclinic','triclinic'
     resolution : float
-        An angle in degrees representing the worst-case angular distance
-        to a first nearest neighbor grid point.
+        An angle in degrees representing the worst-case angular
+        distance to a first nearest neighbor grid point.
     mesh : str
         Type of meshing of the sphere that defines how the grid is
         created. Options are: uv_sphere, normalized_cube,
-        spherified_cube_corner, spherified_cube_edge (default),
+        spherified_cube_corner (default), spherified_cube_edge,
         icosahedral, random.
 
     Returns
@@ -220,9 +221,10 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_e
         points_in_cartesians = get_random_sphere_vertices(resolution)
     else:
         raise NotImplementedError(
-            f"The mesh {mesh} is not recognized. Please use: uv_sphere, "
-            "normalized_cube, spherified_cube_edge, spherified_cube_corner, "
-            "icosahedral, random"
+            f"The mesh {mesh} is not recognized. "
+            f"Please use: uv_sphere, normalized_cube, "
+            f"spherified_cube_edge, "
+            f"spherified_cube_corner, icosahedral, random"
         )
 
     # crop to stereographic triangle which depends on crystal system
@@ -230,6 +232,9 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_e
     if crystal_system == "triclinic":
         return beam_directions_grid_to_euler(points_in_cartesians)
     if crystal_system == "monoclinic":
+        points_in_cartesian = points_in_cartesians[
+            np.dot(np.array([0, 0, 1]), points_in_cartesians.T) >= epsilon
+        ]
         points_in_cartesian = points_in_cartesians[
             np.dot(np.array([1, 0, 0]), points_in_cartesians.T) >= epsilon
         ]
@@ -256,5 +261,4 @@ def get_beam_directions_grid(crystal_system, resolution, mesh="spherified_cube_e
     ]
 
     angle_grid = beam_directions_grid_to_euler(points_in_cartesians)
-
     return angle_grid

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -67,7 +67,7 @@ def get_list_from_orix(grid, rounding=2):
     rotation_list : list of tuples
         A rotation list
     """
-    z = grid.to_euler(convention="bunge")
+    z = grid.to_euler()
     rotation_list = z.data.tolist()
     i = 0
     while i < len(rotation_list):
@@ -122,7 +122,7 @@ def get_local_grid(resolution=2, center=None, grid_width=10):
     """
     if isinstance(center, tuple):
         z = np.deg2rad(np.asarray(center))
-        center = Rotation.from_euler(z, convention="bunge", direction="crystal2lab")
+        center = Rotation.from_euler(z)
 
     orix_grid = get_sample_local(
         resolution=resolution, center=center, grid_width=grid_width
@@ -153,11 +153,11 @@ def get_grid_around_beam_direction(beam_rotation, resolution, angular_range=(0, 
     Examples
     --------
     >>> from diffsims.generators.zap_map_generator import get_rotation_from_z_to_direction
-    >>> beam_rotation = get_rotation_from_z_to_direction(structure,[1,1,1])
-    >>> grid = get_grid_around_beam_direction(beam_rotation,1)
+    >>> beam_rotation = get_rotation_from_z_to_direction(structure, [1, 1, 1])
+    >>> grid = get_grid_around_beam_direction(beam_rotation, 1)
     """
     z = np.deg2rad(np.asarray(beam_rotation))
-    beam_rotation = Rotation.from_euler(z, convention="bunge", direction="crystal2lab")
+    beam_rotation = Rotation.from_euler(z)
 
     angles = np.deg2rad(
         np.arange(start=angular_range[0], stop=angular_range[1], step=resolution)

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,27 +1,30 @@
 name = "diffsims"
-version = "0.5.dev0"
+version = "0.5.0"
 author = "Duncan Johnstone, Phillip Crout"
-copyright = "Copyright 2017-2022, The pyXem developers"
+copyright = "Copyright 2017-2022, The diffsims developers"
+# Initial committer first, then listed by line additions
 credits = [
     "Duncan Johnstone",
     "Phillip Crout",
+    "Håkon Wiik Ånes",
+    "Eric Prestat",
+    "Rob Tovey",
     "Simon Høgås",
     "Ben Martineau",
-    "Isabel Wood",
-    "Håkon Wiik Ånes",
-    "Joonatan Laulainen",
-    "Stef Smeets",
-    "Sean Collins",
-    "Endre Jacobsen",
     "Niels Cautaerts",
-    "Eric Prestat",
+    "Joonatan Laulainen",
+    "Isabel Wood",
+    "Sean Collins",
+    "Stef Smeets",
+    "Alex Borrelli",
     "Tiarnan Doherty",
     "Jedrzej Morzy",
-    "Tomas Ostasevicius",
-    "Alex Borrelli",
+    "Endre Jacobsen",
     "Tina Bergh",
+    "Tomas Ostasevicius",
+    "Eirik Opheim",
 ]
-license = "GPLv3"
+license = "GPLv3+"
 maintainer = "Duncan Johnstone, Phillip Crout, Håkon Wiik Ånes"
 email = "pyxem.team@gmail.com"
 status = "Development"

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.5.0"
+version = "0.5.0rc1"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2022, The diffsims developers"
 # Initial committer first, then listed by line additions

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
+import pytest
+
 from diffsims.generators.rotation_list_generators import (
     get_local_grid,
     get_grid_around_beam_direction,
@@ -73,7 +74,7 @@ def test_get_grid_around_beam_direction():
     ],
 )
 def test_get_beam_directions_grid(crystal_system, mesh):
-    grid = get_beam_directions_grid(crystal_system, 5, mesh=mesh)
+    _ = get_beam_directions_grid(crystal_system, 5, mesh=mesh)
 
 
 @pytest.mark.xfail()

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -18,8 +18,10 @@
 
 import numpy as np
 import pytest
-from diffsims.sims.diffraction_simulation import DiffractionSimulation
-from diffsims.sims.diffraction_simulation import ProfileSimulation
+
+from diffsims.sims.diffraction_simulation import (
+    DiffractionSimulation, ProfileSimulation
+)
 
 
 def test_wrong_calibration_setting():
@@ -137,6 +139,7 @@ class TestDiffractionSimulation:
                 ]
             ),
         )
+        assert sim.size == 4
 
     def test_extend(self, diffraction_simulation):
         diffraction_simulation.extend(diffraction_simulation)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ from os.path import relpath, dirname
 import re
 import sys
 
-from diffsims import __author__, __version__, __file__
+from diffsims import __author__, __file__, __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -50,11 +50,11 @@ extensions = [
 # Create links to references within diffsims' documentation to these packages
 intersphinx_mapping = {
     "diffpy.structure": ("https://www.diffpy.org/diffpy.structure", None),
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "orix": ("https://orix.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -86,7 +86,7 @@ def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object.
 
     This is taken from SciPy's conf.py:
-    https://github.com/scipy/scipy/blob/master/doc/source/conf.py.
+    https://github.com/scipy/scipy/blob/develop/doc/source/conf.py.
     """
     if domain != "py":
         return None
@@ -131,12 +131,12 @@ def linkcode_resolve(domain, info):
     fn = relpath(fn, start=startdir).replace(os.path.sep, "/")
 
     if fn.startswith("diffsims/"):
-        m = re.match(r"^.*dev0\+([a-f0-9]+)$", __version__)
+        m = re.match(r"^.*dev0\+([a-f\d]+)$", __version__)
         pre_link = "https://github.com/pyxem/diffsims/blob/"
         if m:
             return pre_link + "%s/%s%s" % (m.group(1), fn, linespec)
         elif "dev" in __version__:
-            return pre_link + "master/%s%s" % (fn, linespec)
+            return pre_link + "develop/%s%s" % (fn, linespec)
         else:
             return pre_link + "v%s/%s%s" % (__version__, fn, linespec)
     else:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,10 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        (
+            "License :: OSI Approved :: GNU General Public License v3 or later "
+            "(GPLv3+)"
+        ),
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering",
@@ -63,7 +66,8 @@ setup(
         "matplotlib         >= 3.3",
         "numba",
         "numpy              >= 1.17",
-        "orix               >= 0.5.0",
+        # TODO: Revert orix minimal to >= 0.4 once 0.9.0rc2 is confirmed to work
+        "orix               == 0.9.0rc2",
         "psutil",
         "scipy              >= 1.0",
         "tqdm               >= 4.9",

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,7 @@ setup(
         "matplotlib         >= 3.3",
         "numba",
         "numpy              >= 1.17",
-        # TODO: Revert orix minimal to >= 0.4 once 0.9.0rc2 is confirmed to work
-        "orix               == 0.9.0rc2",
+        "orix               >= 0.5",
         "psutil",
         "scipy              >= 1.0",
         "tqdm               >= 4.9",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "matplotlib         >= 3.3",
         "numba",
         "numpy              >= 1.17",
-        "orix               >= 0.5",
+        "orix               >= 0.9",
         "psutil",
         "scipy              >= 1.0",
         "tqdm               >= 4.9",


### PR DESCRIPTION
#### Description of the change
These are some minor preparations for a 0.5 release:
* Most importantly, `diffsims` is tested using `orix` v0.9.0rc2: no code changes were necessary!
* The contributor list is updated. @pc494, ~if you want a .zenodo.json file here as well, I'll add it.~ .zenodo.json file added.
* I've updated the Python publish workflow to use the same as with `orix`. I thought we could test this by releasing 0.5.0rc1 before 0.5.0. This way, I can also test `kikuchipy` against `diffsims` 0.5.0.
* Bumped version to 0.5.0rc1
* Updated the license description in setup.py from GPLv3 to GPLv3+, because the license allows for a later v3 license to be used as well. `hyperspy` does this. There isn't a later v3 as far as I know.
* Removed passing the `convention` parameter to `Rotation.from_euler()` which was [deprecated in orix 0.9](https://orix.readthedocs.io/en/stable/changelog.html#deprecated)

Question: should we add a `black` code style check to the CI build action?

#### Progress of the PR

- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)
- [x] Update changelog
- [x] Release orix 0.9
- [x] Revert minial version of orix
- [x] Any other PRs to `master` before release:
    - [x] #184
    - [x] #185
- [x] Update PyPI secrets

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
