### PR TITLE
Fix hexagonal corners of fundamental sector in stereographic projection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Added
 Changed
 -------
 - Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9
+- The Laue group representing the rotation list sampling of "hexagonal" from 6/m to
+  6/mmm.
 
 2021-04-16 - version 0.4.2
 ==========================

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -43,7 +43,7 @@ from diffsims.generators.sphere_mesh_generators import (
 # https://github.com/pyxem/orix/issues/125#issuecomment-698956290.
 crystal_system_dictionary = {
     "cubic": [(0, 0, 1), (1, 1, 1), (1, 0, 1)],
-    "hexagonal": [(0, 0, 0, 1), (1, 0, -1, 0), (2, -1, -1, 0)],
+    "hexagonal": [(0, 0, 0, 1), (9, 1, -10, 0), (2, -1, -1, 0)],
     "trigonal": [(0, 0, 0, 1), (-2, 1, 1, 0), (-1, 2, -1, 0)],
     "tetragonal": [(0, 0, 1), (1, 0, 0), (1, 1, 0)],
     "orthorhombic": [(0, 0, 1), (-1, 0, 0), (0, 1, 0)],

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -76,6 +76,23 @@ def test_get_beam_directions_grid(crystal_system, mesh):
     grid = get_beam_directions_grid(crystal_system, 5, mesh=mesh)
 
 
+@pytest.mark.parametrize(
+    "crystal_system, desired_size",
+    [
+        ("cubic", 300),
+        ("hexagonal", 1050),
+        ("trigonal", 1657),
+        ("tetragonal", 852),
+        ("orthorhombic", 1657),
+        ("monoclinic", 6441),
+        ("triclinic", 12698),
+    ]
+)
+def test_get_beam_directions_grid_size(crystal_system, desired_size):
+    grid = get_beam_directions_grid(crystal_system, 2)
+    assert grid.shape[0] == desired_size
+
+
 @pytest.mark.xfail()
 def test_invalid_mesh_beam_directions():
     _ = get_beam_directions_grid("cubic", 10, mesh="invalid")

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -88,18 +88,21 @@ def test_plot_profile_simulation(profile_simulation):
 class TestDiffractionSimulation:
     @pytest.fixture
     def diffraction_simulation(self):
-        return DiffractionSimulation(np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]))
+        return DiffractionSimulation(
+            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]], dtype=float)
+        )
 
     @pytest.fixture
     def diffraction_simulation_calibrated(self):
         return DiffractionSimulation(
-            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), calibration=0.5
+            np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]], dtype=float), calibration=0.5
         )
 
     def test_failed_initialization(self):
         with pytest.raises(ValueError, match="Coordinate"):
             DiffractionSimulation(
-                np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]]), indices=np.array([1, 2, 3])
+                np.array([[0, 0, 0], [1, 2, 3], [3, 4, 5]], dtype=float),
+                indices=np.array([1, 2, 3])
             )
 
     def test_init(self, diffraction_simulation):


### PR DESCRIPTION
#### Description of the change
Change the rounded hexagonal corner [10-10] to the exact [9 1 -10 0]. See #183 for details.

Also fixed a rounding error in a test when coordinates passed to `DiffractionSimulation` where integers and not floats.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
