### PR TITLE
Loosen angle tolerance in DiffractionLibrary.get_library_entry() from 1e-5 to 1e-2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,15 +14,17 @@ Unreleased
 Added
 -----
 - Extra parameters in diffraction pattern's plot method for drawing miller index labels
-  next to the diffraction spots
-- Option to use None for `scattering_params` which ignores atomic scattering
+  next to the diffraction spots.
+- Option to use None for ``scattering_params`` which ignores atomic scattering.
 - Python 3.10 support.
 
 Changed
 -------
-- Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9
+- Minimal version of dependencies numpy >= 1.17 and tqdm >= 4.9.
 - The Laue group representing the rotation list sampling of "hexagonal" from 6/m to
   6/mmm.
+- Loosened the angle tolerance in ``DiffractionLibrary.get_library_entry()`` from
+  ``1e-5`` to ``1e-2``.
 
 2021-04-16 - version 0.4.2
 ==========================

--- a/diffsims/libraries/diffraction_library.py
+++ b/diffsims/libraries/diffraction_library.py
@@ -17,6 +17,7 @@
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
 import pickle
+
 import numpy as np
 
 
@@ -26,18 +27,19 @@ def load_DiffractionLibrary(filename, safety=False):
     Parameters
     ----------
     filename : str
-        The location of the file to be loaded
-    safety : bool (defaults to False)
-        Unpickling is risky, this variable requires you to acknowledge this.
+        The location of the file to be loaded.
+    safety : bool
+        Unpickling is risky, this variable requires you to acknowledge
+        this. Default is False.
 
     Returns
     -------
     DiffractionLibrary
-        Previously saved Library
+        Previously saved Library.
 
     See Also
     --------
-    DiffractionLibrary.pickle_library()
+    DiffractionLibrary.pickle_library
 
     """
     if safety:
@@ -45,43 +47,44 @@ def load_DiffractionLibrary(filename, safety=False):
             return pickle.load(handle)
     else:
         raise RuntimeError(
-            "Unpickling is risky, turn safety to True if \
-        trust the author of this content"
+            "Unpickling is risky, turn safety to True if you trust the author of this "
+            "content"
         )
 
 
 def _get_library_entry_from_angles(library, phase, angles):
-    """Finds an element that is orientation within 1e-5 of that specified.
+    """Finds an element that is orientation within 1e-2 of that
+    specified.
 
-    This is necessary because of floating point round off / hashability. If
-    multiple entries satisfy the above criterion a random (the first hit)
-    selection is made.
+    This is necessary because of floating point round off / hashability.
+    If multiple entries satisfy the above criterion a random (the first
+    hit) selection is made.
 
     Parameters
     ----------
     library : DiffractionLibrary
-        The library to be searched
+        The library to be searched.
     phase : str
         The phase of interest.
     angles : tuple
-        The orientation of interest as a tuple of Euler angles following the
-        Bunge convention [z, x, z] in degrees.
+        The orientation of interest as a tuple of Euler angles in
+        degrees, following the Bunge convention [z, x, z].
 
     Returns
     -------
     orientation_index : int
-        Index of the given orientation
+        Index of the given orientation.
 
     """
 
     phase_entry = library[phase]
     for orientation_index, orientation in enumerate(phase_entry["orientations"]):
-        if np.sum(np.abs(np.subtract(orientation, angles))) < 1e-5:
+        if np.sum(np.abs(np.subtract(orientation, angles))) < 1e-2:
             return orientation_index
 
     # We haven't found a suitable key
     raise ValueError(
-        "It appears that no library entry lies with 1e-5 of the target angle"
+        "It appears that no library entry lies with 1e-2 of the target angle"
     )
 
 

--- a/diffsims/tests/library/test_diffraction_library.py
+++ b/diffsims/tests/library/test_diffraction_library.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import os
+
 import numpy as np
+import pytest
 
 from diffsims.generators.diffraction_generator import DiffractionGenerator
 from diffsims.generators.library_generator import DiffractionLibraryGenerator
-
-from diffsims.sims.diffraction_simulation import DiffractionSimulation
-
 from diffsims.libraries.diffraction_library import load_DiffractionLibrary
 from diffsims.libraries.structure_library import StructureLibrary
+from diffsims.sims.diffraction_simulation import DiffractionSimulation
 
 
 @pytest.fixture
@@ -80,24 +79,24 @@ def test_library_io(get_library):
         )
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_angle_but_no_phase(get_library):
     # we have given an angle but no phase
-    assert isinstance(
-        get_library.get_library_entry(angle=(0, 0, 0))["Sim"], DiffractionSimulation
-    )
+    with pytest.raises(ValueError, match="To select a certain angle you must first "):
+        assert isinstance(
+            get_library.get_library_entry(angle=(0, 0, 0))["Sim"], DiffractionSimulation
+        )
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_unknown_library_entry(get_library):
     # The angle we have asked for is not in the library
-    assert isinstance(
-        get_library.get_library_entry(phase="Phase", angle=(1e-3, 0, 0))["Sim"],
-        DiffractionSimulation,
-    )
+    with pytest.raises(ValueError, match="It appears that no library entry lies"):
+        assert isinstance(
+            get_library.get_library_entry(phase="Phase", angle=(1e-1, 0, 0))["Sim"],
+            DiffractionSimulation,
+        )
 
 
-@pytest.mark.xfail(raises=RuntimeError)
 def test_unsafe_loading(get_library):
-    get_library.pickle_library("file_01.pickle")
-    loaded_library = load_DiffractionLibrary("file_01.pickle")
+    with pytest.raises(RuntimeError, match="Unpickling is risky, turn safety to True "):
+        get_library.pickle_library("file_01.pickle")
+        _ = load_DiffractionLibrary("file_01.pickle")


### PR DESCRIPTION
#### Description of the change
Fix #173.

Also changed three diffraction library tests raising errors to also check for the specific error message.

Note that the one line that is not covered in this PR is covered in #182.

#### Progress of the PR

- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
