### PR TITLE
Prepare for official 0.5.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-06-01 - version 0.5.0
+2022-06-10 - version 0.5.0
 ==========================
 
 Added

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.5.0rc1"
+version = "0.5.0"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2022, The diffsims developers"
 # Initial committer first, then listed by line additions


### PR DESCRIPTION
#### Description of the change
The release candidate of 0.5.0 went out smoothly, and the two downstream packages pyxem and kikuchipy work with this release. I suggest to merge this on Friday June 3 and release.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.