### PR TITLE
Fix allowed vectors when (hkl) are slightly off integers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,17 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+    workflow: '*'
+
+env:
+  MPLBACKEND: agg
 
 jobs:
   # Make sure all necessary files will be included in a release
@@ -8,9 +19,9 @@ jobs:
     name: check manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install dependencies
         run: pip install manifix
@@ -19,11 +30,9 @@ jobs:
         run: python setup.py manifix
 
   build-with-pip:
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.label }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    env:
-      MPLBACKEND: agg
     strategy:
       fail-fast: false
       matrix:
@@ -31,46 +40,48 @@ jobs:
         python-version: [3.9, '3.10']
         include:
           # Oldest supported version of main dependencies on Python 3.6
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: 3.6
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.9.0 scipy==1.0 tqdm==4.9
             LABEL: -oldest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Display Python and pip versions
-        run: |
-          python -V
-          pip -V
-
       - name: Install dependencies and package
         shell: bash
-        run: pip install -U -e .'[tests]'
+        run: |
+          pip install -U -e .'[tests]'
 
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
-        run: pip install ${{ matrix.DEPENDENCIES }}
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
 
-      - name: Display package versions
-        run: pip list
+      - name: Display Python, pip and package versions
+        run: |
+          python -V
+          pip -V
+          pip list
 
       - name: Run docstring tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         continue-on-error: true
-        run: pytest --doctest-modules --ignore-glob=diffsims/tests/*
+        run: |
+          pytest --doctest-modules --doctest-continue-on-failure --ignore-glob=diffsims/tests/*
 
       - name: Run tests
-        run: pytest --cov=diffsims --pyargs diffsims
+        run: pytest -n 2 --cov=diffsims --pyargs diffsims
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: coverage report --show-missing
+        run: |
+          coverage report --show-missing
 
       - name: Upload coverage to Coveralls
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,7 +76,7 @@ Fixed
 
 Added
 -----
-- API reference documentation via Read The Docs: https://diffsims.readthedocs.io
+- API reference documentation via Read The Docs: https://diffsims.readthedocs.io/en/latest/
 - New module: `sphere_mesh_generators`
 - New module: `detector_functions`
 - New module: `ring_pattern_utils`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Fixed
   selection of which vectors are allowed or not given a lattice centering. Integer
   indices are assumed.
 
+Deprecated
+----------
+- Support for Python 3.6 is deprecated and will be removed in v0.6.
+
 2022-06-10 - version 0.5.0
 ==========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
+2023-01-25 - version 0.5.1
+==========================
+
+Fixed
+-----
+- ``ReciprocalLatticeVector.allowed`` rounds indices (hkl) internally to ensure correct
+  selection of which vectors are allowed or not given a lattice centering. Integer
+  indices are assumed.
+
 2022-06-10 - version 0.5.0
 ==========================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ this guide boils down to using that platform well. so visit the following link a
 around the code, issues, and pull requests (PRs): `diffsims
 on GitHub <https://github.com/pyxem/diffsims>`_.
 
-It's probably also worth visiting the `GitHub guides <https://guides.github.com>`_ to
+It's probably also worth visiting the `GitHub guides <https://docs.github.com/en>`_ to
 get a feel for the terminology.
 
 In brief, to give you a hint on the terminology to search for, the contribution pattern
@@ -70,7 +70,7 @@ Git is an open source "version control" system that enables you to can separate 
 modifications to the code into many versions (called branches) and switch between them
 easily. Later you can choose which version you want to have integrated into diffsims.
 
-You can learn all about Git `here <http://www.git-scm.com/about>`_!
+You can learn all about Git `here <https://www.git-scm.com/about>`_!
 
 The most important thing is to separate your contributions so that each branch is a
 small advancement on the "master" code or on another branch.
@@ -80,7 +80,7 @@ Get the style right
 
 diffsims closely follows the Style Guide for Python Code - these are just some rules for
 consistency that you can read all about in the `Python Style Guide
-<https://www.python.org/dev/peps/pep-0008/>`_.
+<https://peps.python.org/pep-0008/>`_.
 
 Please run the latest version of
 `black <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_ on
@@ -89,18 +89,18 @@ your newly added and modified files prior to each PR.
 Run and write tests
 -------------------
 
-All functionality in diffsims is tested via the `pytest <https://docs.pytest.org>`_
-framework. The tests reside in the ``diffsims.tests`` module. Tests are short functions
-that call functions in diffsims and compare resulting output values with known answers.
-Good tests should depend on as few other features as possible so that when they break we
-know exactly what caused it.
+All functionality in diffsims is tested via the `pytest
+<https://docs.pytest.org/en/stable/>`_ framework. The tests reside in the
+``diffsims.tests`` module. Tests are short functions that call functions in diffsims and
+compare resulting output values with known answers. Good tests should depend on as few
+other features as possible so that when they break we know exactly what caused it.
 
 Install necessary dependencies to run the tests::
 
    pip install --editable .[tests]
 
-Some useful `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_ are available
-in the ``conftest.py`` file.
+Some useful `fixtures <https://docs.pytest.org/en/latest/explanation/fixtures.html>`_
+are available in the ``conftest.py`` file.
 
 To run the tests::
 
@@ -122,16 +122,15 @@ Useful hints on testing:
 - ``@pytest.mark.parametrize()`` is a convenient decorator to test several parameters of
   the same function without having to write to much repetitive code, which is often
   error-prone. See `pytest documentation for more details
-  <http://doc.pytest.org/en/latest/parametrize.html>`_.
+  <https://doc.pytest.org/en/latest/how-to/parametrize.html>`_.
 
 Build and write documentation
 -----------------------------
 
 Docstrings -- written at the start of a function -- give essential information about how
 it should be used, such as which arguments can be passed to it and what the syntax
-should be. The docstrings follow the `NumPy specification
-<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_,
-as shown in `this example <https://github.com/numpy/numpy/blob/master/doc/example.py>`_.
+should be. The docstrings mostly follow the `numpydoc
+<https://numpydoc.readthedocs.io/en/latest/format.html>`_ standard.
 
 We use `Sphinx <https://www.sphinx-doc.org/en/master>`_ for documenting functionality.
 Install necessary dependencies to build the documentation::

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@
 .. |docs| image:: https://readthedocs.org/projects/diffsims/badge/?version=latest
 .. _docs: https://diffsims.readthedocs.io/en/latest
 
-.. |pypi_version| image:: http://img.shields.io/pypi/v/diffsims.svg?style=flat
-.. _pypi_version: https://pypi.python.org/pypi/diffsims
+.. |pypi_version| image:: https://img.shields.io/pypi/v/diffsims.svg?style=flat
+.. _pypi_version: https://pypi.org/project/diffsims/
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
 .. _black: https://github.com/psf/black
@@ -23,7 +23,7 @@ diffsims is an open-source Python library for simulating diffraction.
 If simulations performed using diffsims form a part of published work please
 cite the DOI at the top of this page. You can find demos in the `diffsims-demos
 <https://github.com/pyxem/diffsims-demos>`_ repository. See the `documentation
-<https://diffsims.readthedocs.io>`_ for installation instructions, the API reference,
-the changelog and more.
+<https://diffsims.readthedocs.io/en/latest/>`_ for installation instructions, the API
+reference, the changelog and more.
 
 diffsims is released under the GPL v3 license.

--- a/diffsims/__init__.py
+++ b/diffsims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/conftest.py
+++ b/diffsims/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/__init__.py
+++ b/diffsims/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/reciprocal_lattice_point.py
+++ b/diffsims/crystallography/reciprocal_lattice_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/reciprocal_lattice_vector.py
+++ b/diffsims/crystallography/reciprocal_lattice_vector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/reciprocal_lattice_vector.py
+++ b/diffsims/crystallography/reciprocal_lattice_vector.py
@@ -59,8 +59,8 @@ class ReciprocalLatticeVector(Vector3d):
     Create a set of reciprocal lattice vectors from :math:`(hkl)` or
     :math:`(hkil)`.
 
-    The vectors are internally as cartesian coordinates in the ``data``
-    attribute.
+    The vectors are stored internally as cartesian coordinates in
+    :attr:`data`.
 
     Parameters
     ----------
@@ -583,6 +583,8 @@ class ReciprocalLatticeVector(Vector3d):
         """Return whether vectors diffract according to diffraction
         selection rules assuming kinematic scattering theory.
 
+        Integer vectors are assumed.
+
         Returns
         -------
         allowed : numpy.ndarray
@@ -614,20 +616,22 @@ class ReciprocalLatticeVector(Vector3d):
         # Translational symmetry
         centering = self.phase.space_group.short_name[0]
 
+        hkl = self.hkl.round().astype(int).reshape(-1, 3)
+
         if centering == "A":  # Centred on A faces only
-            return np.isclose(np.mod(self.k + self.l, 2), 0)
+            return np.isclose(np.mod(hkl[:, 1] + hkl[:, 2], 2), 0)
         elif centering == "B":  # Centred on B faces only
-            return np.isclose(np.mod(self.h + self.l, 2), 0)
+            return np.isclose(np.mod(hkl[:, 0] + hkl[:, 2], 2), 0)
         elif centering == "C":  # Centred on C faces only
-            return np.isclose(np.mod(self.h + self.k, 2), 0)
+            return np.isclose(np.mod(hkl[:, 0] + hkl[:, 1], 2), 0)
         elif centering == "F":  # Face-centred, hkl all odd/even
-            selection = np.sum(np.mod(self.hkl, 2), axis=-1)
+            selection = np.sum(np.mod(hkl, 2), axis=-1)
             return np.array([i not in [1, 2] for i in selection], dtype=bool)
         elif centering == "I":  # Body-centred, h + k + l = 2n (even)
-            return np.isclose(np.mod(np.sum(self.hkl, axis=-1), 2), 0)
+            return np.isclose(np.mod(np.sum(hkl, axis=-1), 2), 0)
         elif centering in ["R", "H"]:  # Rhombohedral obverse
             # Consider Rhombohedral reverse?
-            return np.isclose(np.mod(-self.h + self.k + self.l, 3), 0)
+            return np.isclose(np.mod(-hkl[:, 0] + hkl[:, 1] + hkl[:, 2], 3), 0)
         elif centering == "P":  # Primitive
             if self.has_hexagonal_lattice:
                 # TODO: See rules in e.g.

--- a/diffsims/generators/__init__.py
+++ b/diffsims/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -143,7 +143,7 @@ def get_cube_mesh_vertices(resolution, grid_type="spherified_corner"):
     References
     ----------
     .. [Cajaravelli2015] O. S. Cajaravelli, "Four Ways to Create a Mesh for a Sphere,"
-        https://medium.com/game-dev-daily/four-ways-to-create-a-mesh-for-a-sphere-d7956b825db4.
+        https://medium.com/@oscarsc/four-ways-to-create-a-mesh-for-a-sphere-d7956b825db4.
     """
     # the angle between 001 and 011
     max_angle = np.deg2rad(45)
@@ -385,8 +385,7 @@ def get_icosahedral_mesh_vertices(resolution):
 
     References
     ----------
-    .. [Meshzoo] The `meshzoo.sphere` module,
-        https://github.com/nschloe/meshzoo/blob/master/meshzoo/sphere.py.
+    .. [Meshzoo] The `meshzoo.sphere` module.
     """
     t = (1.0 + np.sqrt(5.0)) / 2.0
     corners = np.array(

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/zap_map_generator.py
+++ b/diffsims/generators/zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/__init__.py
+++ b/diffsims/libraries/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/diffraction_library.py
+++ b/diffsims/libraries/diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/vector_library.py
+++ b/diffsims/libraries/vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/__init__.py
+++ b/diffsims/pattern/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.5.0"
+version = "0.5.1"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2022, The diffsims developers"
 # Initial committer first, then listed by line additions

--- a/diffsims/sims/__init__.py
+++ b/diffsims/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/__init__.py
+++ b/diffsims/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_factor.py
+++ b/diffsims/structure_factor/atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/structure_factor.py
+++ b/diffsims/structure_factor/structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/__init__.py
+++ b/diffsims/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/__init__.py
+++ b/diffsims/tests/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_reciprocal_lattice_point.py
+++ b/diffsims/tests/crystallography/test_reciprocal_lattice_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
+++ b/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2021 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
+++ b/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
@@ -213,6 +213,15 @@ class TestReciprocalLatticeVector:
         with pytest.raises(ValueError):
             _ = rlv.allowed
 
+    def test_allowed_decimals(self, nickel_phase):
+        """Rounding of Miller indices gives expected allowed vectors."""
+        rlv = ReciprocalLatticeVector.from_min_dspacing(nickel_phase)
+        rlv.sanitise_phase()
+        rlv.calculate_structure_factor()
+        structure_factor = abs(rlv.structure_factor)
+        rlv = rlv[structure_factor > 0.4 * structure_factor.max()]
+        assert all(rlv.allowed)
+
     @pytest.mark.parametrize(
         "voltage, hkl, desired_theta",
         [(20e3, [1, 1, 1], 0.0259313), (200e3, [2, 0, 0], 0.008748)],

--- a/diffsims/tests/generators/__init__.py
+++ b/diffsims/tests/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_library_generator.py
+++ b/diffsims/tests/generators/test_library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/generators/test_sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_zap_map_generator.py
+++ b/diffsims/tests/generators/test_zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/__init__.py
+++ b/diffsims/tests/library/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_diffraction_library.py
+++ b/diffsims/tests/library/test_diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_structure_library.py
+++ b/diffsims/tests/library/test_structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_vector_library.py
+++ b/diffsims/tests/library/test_vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/patterns/__init__.py
+++ b/diffsims/tests/patterns/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/__init__.py
+++ b/diffsims/tests/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/__init__.py
+++ b/diffsims/tests/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_parameters.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_structure_factor.py
+++ b/diffsims/tests/structure_factor/test_structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/__init__.py
+++ b/diffsims/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
+++ b/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_discretise_utils.py
+++ b/diffsims/tests/utils/test_discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_fourier_transform.py
+++ b/diffsims/tests/utils/test_fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_generic_utils.py
+++ b/diffsims/tests/utils/test_generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_kinematic_simulation_utils.py
+++ b/diffsims/tests/utils/test_kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_mask_utils.py
+++ b/diffsims/tests/utils/test_mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_probe_utils.py
+++ b/diffsims/tests/utils/test_probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_ring_pattern_utils.py
+++ b/diffsims/tests/utils/test_ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_vector_utils.py
+++ b/diffsims/tests/utils/test_vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/__init__.py
+++ b/diffsims/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_diffraction_generator_utils.py
+++ b/diffsims/utils/atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_scattering_params.py
+++ b/diffsims/utils/atomic_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/fourier_transform.py
+++ b/diffsims/utils/fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/generic_utils.py
+++ b/diffsims/utils/generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/kinematic_simulation_utils.py
+++ b/diffsims/utils/kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/lobato_scattering_params.py
+++ b/diffsims/utils/lobato_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/probe_utils.py
+++ b/diffsims/utils/probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/ring_pattern_utils.py
+++ b/diffsims/utils/ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/scattering_params.py
+++ b/diffsims/utils/scattering_params.py
@@ -22,7 +22,7 @@ Scattering Paramaters as Tabulated in
 ISBN 978-1-4419-6532-5
 Pages 253-260 Appendix C
 
-This transcription comes from scikit-ued (MIT license) - https://pypi.python.org/pypi/scikit-ued
+This transcription comes from scikit-ued (MIT license) - https://pypi.org/project/scikit-ued/
 """
 
 import numpy as np

--- a/diffsims/utils/scattering_params.py
+++ b/diffsims/utils/scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/vector_utils.py
+++ b/diffsims/utils/vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -4,9 +4,10 @@ Related projects
 
 Related, open-source projects that users of diffsims might find useful:
 
-- `pyxem <https://github.com/pyxem/pyxem>`_: Python library for multi-dimensional
-  diffraction microscopy. Uses diffsims.
-- `orix <https://github.com/pyxem/orix>`_: Python library for handling crystal
-  orientation mapping data.
-- `kikuchipy <https://kikuchipy.org>`_: Python library for processing and analysis of
-  electron backscatter diffraction (EBSD) patterns. Uses diffsims.
+- `pyxem <https://pyxem.readthedocs.io/en/stable>`_: Python library for
+  multi-dimensional diffraction microscopy. Uses diffsims.
+- `orix <https://orix.readthedocs.io/en/stable>`_: Python library for handling crystal
+  orientation mapping data. diffsims depends on orix.
+- `kikuchipy <https://kikuchipy.org/en/stable>`_: Python library for processing,
+  simulating and indexing of electron backscatter diffraction (EBSD) patterns. Uses
+  diffsims.

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,25 @@ exec(open("diffsims/release_info.py").read())  # grab version info
 # Projects with optional features for building the documentation and running
 # tests. From setuptools:
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+# fmt: off
 extra_feature_requirements = {
-    "doc": ["furo", "sphinx >= 3.0.2"],
-    "tests": ["pytest >= 5.4", "pytest-cov >= 2.8.1", "coverage >= 5.0"],
+    "doc": [
+        "furo",
+        "sphinx         >= 3.0.2"
+    ],
+    "tests": [
+        "pytest         >= 5.4",
+        "pytest-cov     >= 2.8.1",
+        "pytest-xdist",
+        "coverage       >= 5.0"
+    ],
 }
-extra_feature_requirements["dev"] = ["black >= 19.3b0", "pre-commit >= 1.16"] + list(
-    chain(*list(extra_feature_requirements.values()))
-)
+extra_feature_requirements["dev"] = [
+    "black              >= 19.3b0",
+    "manifix",
+    "pre-commit         >= 1.16"
+] + list(chain(*list(extra_feature_requirements.values())))
+# fmt: on
 
 setup(
     name=name,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2022 The diffsims developers
+# Copyright 2017-2023 The diffsims developers
 #
 # This file is part of diffsims.
 #


### PR DESCRIPTION
#### Description of the change
This patch fixes calculation of allowed vectors in `ReciprocalLatticeVector.allowed` when vectors (hkl) are slightly off integers. A test has been added that only passes with this patch. See example below for a demonstration.

I suggest to make a patch release v0.5.1 immediately after this branch has been merged onto `main` (I renamed the main branch from `master` to `main`). There has been no activity since the v0.5.0 release, so that should be OK.

Other changes I've made:
* Run tests in parallel on two threads on GitHub actions with `pytest-xdist` (test dependency). Should reduce the test time by about half.
* Ran `make linkcheck` on the docs and updated some links (had to remove some since I couldn't find a replacement).

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### Minimal example of the bug fix or new feature
Only all odd or all even (hkl) are allowed in face-centered cubic lattices. Below we create a set of vectors which all should be allowed.

```python
>>> from diffpy.structure import Atom, Lattice, Structure
>>> from orix.crystal_map import Phase
>>> from diffsims.crystallography import ReciprocalLatticeVector
>>> phase = Phase(
...     name="nickel",
...     space_group=225,
...     structure=Structure(
...         lattice=Lattice(3.5236, 3.5236, 3.5236, 90, 90, 90),
...         atoms=[Atom(xyz=[0, 0, 0], atype="Ni", Uisoequiv=0.006332)],
...     ),
... )
>>> rlv = ReciprocalLatticeVector.from_min_dspacing(phase)
>>> rlv.sanitise_phase()
>>> rlv.calculate_structure_factor()
>>> structure_factor = abs(rlv.structure_factor)
>>> rlv = rlv[structure_factor > 0.4 * structure_factor.max()]
>>> rlv.print_table()
 h k l      d     |F|_hkl   |F|^2   |F|^2_rel   Mult 
 1 1 1    2.034    11.8     140.0     100.0      8   
 2 0 0    1.762    10.4     108.2      77.3      6   
 2 2 0    1.246     7.4     55.0       39.3      12  
 3 1 1    1.062     6.2     38.6       27.6      24  
 2 2 2    1.017     5.9     34.7       24.8      8   
 4 0 0    0.881     4.9     23.9       17.1      6   

# Before this fix

>>> rlv.allowed
array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True, False,  True, False,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True, False,  True,  True,  True,  True, False,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True, False,  True, False,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True])

# After this fix

array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True,
        True])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.