### PR TITLE
Silence Numba warnings by always using no-python mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 and this project adheres to `Semantic Versioning
 <https://semver.org/spec/v2.0.0.html>`_.
 
+2023-05-22 - version 0.5.2
+==========================
+
+Fixed
+-----
+- Always use no-python mode to silence Numba deprecation warnings.
+
 2023-01-25 - version 0.5.1
 ==========================
 

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,7 +1,7 @@
 name = "diffsims"
-version = "0.5.1"
+version = "0.5.2"
 author = "Duncan Johnstone, Phillip Crout"
-copyright = "Copyright 2017-2022, The diffsims developers"
+copyright = "Copyright 2017-2023, The diffsims developers"
 # Initial committer first, then listed by line additions
 credits = [
     "Duncan Johnstone",

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -138,7 +138,7 @@ def get_atoms(Z, returnFunc=True, dtype=FTYPE):
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(fastmath=True, nopython=True)
+@numba.njit(fastmath=True)
 def __linear_interp(x, i, arr):  # pragma: no cover
     # First order Lagrange interpolation: x_0=0, x_1=1
     # L_0(x) = (x-x_1)/(x_0-x_1) = 1-x
@@ -147,7 +147,7 @@ def __linear_interp(x, i, arr):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(fastmath=True, nopython=True)
+@numba.njit(fastmath=True)
 def __quadratic_interp(x, i, arr):  # pragma: no cover
     # Second order Lagrange interpolation: x_0=-1, x_1=0, x_2=1
     # L_0(x) = (x-x_1)*(x-x_2)/(x_0-x_1)/(x_0-x_2) = x*(x-1)/-1/-2 = x(x-1)/2
@@ -160,7 +160,7 @@ def __quadratic_interp(x, i, arr):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(fastmath=True, nopython=True)
+@numba.njit(fastmath=True)
 def __atom_pw_cpu(x0, x1, x2, pc, h):  # pragma: no cover
     n = x0 * x0 + x1 * x1 + x2 * x2
     if n >= h[0]:
@@ -174,7 +174,7 @@ def __atom_pw_cpu(x0, x1, x2, pc, h):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(fastmath=True, nopython=True)
+@numba.njit(fastmath=True)
 def __atom_av_cpu(x0, x1, x2, pc, h):  # pragma: no cover
     x0, x1, x2 = c_abs(x0), c_abs(x1), c_abs(x2)
     if x0 > h[0, 0] or x1 > h[0, 1] or x2 > h[0, 2]:
@@ -245,7 +245,7 @@ if _CUDA:  # pragma: no cover
 # Binning list of atoms into a grid for efficiency
 ##########
 # Coverage: Numba code does not register when code is run
-@numba.jit(cache=True)
+@numba.njit(cache=True)
 def __countbins(x0, x1, x2, loc, r, s, Len, MAX):  # pragma: no cover
     for j0 in range(loc.shape[0]):
         bin0 = int((loc[j0, 0] - x0) / r[0])
@@ -260,7 +260,7 @@ def __countbins(x0, x1, x2, loc, r, s, Len, MAX):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(cache=True)
+@numba.njit(cache=True)
 def __rebin(x0, x1, x2, loc, sublist, r, s, Len):  # pragma: no cover
     for j0 in range(loc.shape[0]):
         bin0 = int((loc[j0, 0] - x0) / r[0])
@@ -404,7 +404,7 @@ def do_binning(x, loc, Rmax, d, GPU):
 # Discretise whole crystal
 ##########
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, nopython=True)
+@numba.njit(parallel=True, fastmath=True)
 def __density3D_pw_cpu(
     x0, x1, x2, xmin, loc, sublist, r, a, d, B, precomp, h, out
 ):  # pragma: no cover
@@ -436,7 +436,7 @@ def __density3D_pw_cpu(
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, nopython=True)
+@numba.njit(parallel=True, fastmath=True)
 def __density3D_av_cpu(
     x0, x1, x2, xmin, loc, sublist, r, a, d, B, precomp, h, out
 ):  # pragma: no cover
@@ -468,7 +468,7 @@ def __density3D_av_cpu(
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, nopython=True)
+@numba.njit(parallel=True, fastmath=True)
 def __FT3D_pw_cpu(x0, x1, x2, loc, a, b, d, B, precomp, h, out):  # pragma: no cover
     X0 = x0
     for i1 in numba.prange(x1.size):
@@ -486,7 +486,7 @@ def __FT3D_pw_cpu(x0, x1, x2, loc, a, b, d, B, precomp, h, out):  # pragma: no c
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, nopython=True)
+@numba.njit(parallel=True, fastmath=True)
 def __FT3D_av_cpu(x0, x1, x2, loc, a, b, d, B, precomp, h, out):  # pragma: no cover
     X0 = x0
     for i1 in numba.prange(x1.size):

--- a/diffsims/utils/fourier_transform.py
+++ b/diffsims/utils/fourier_transform.py
@@ -352,7 +352,7 @@ def fftshift_phase(x):
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def __fftshift_phase1(x):  # pragma: no cover
     sz = x.shape[0] // 2
     for i in numba.prange(sz):
@@ -360,7 +360,7 @@ def __fftshift_phase1(x):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def __fftshift_phase2(x):  # pragma: no cover
     for i in numba.prange(x.shape[0]):
         start = (i + 1) % 2
@@ -369,7 +369,7 @@ def __fftshift_phase2(x):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def __fftshift_phase3(x):  # pragma: no cover
     for i in numba.prange(x.shape[0]):
         for j in range(x.shape[1]):
@@ -401,7 +401,7 @@ def fast_abs(x, y=None):
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def __fast_abs(x, y):  # pragma: no cover
     for i in numba.prange(x.size):
         y[i] = abs(x[i])
@@ -560,7 +560,7 @@ def get_DFT(X=None, Y=None):
     xmin = [x.item(0) for x in X]
 
     # Coverage: Numba code does not register when code is run
-    @numba.jit(nopython=True, parallel=True, fastmath=True)
+    @numba.njit(parallel=True, fastmath=True)
     def apply_phase_3D(x, f0, f1, f2):  # pragma: no cover
         for i0 in numba.prange(x.shape[0]):
             F0 = f0[i0]

--- a/diffsims/utils/generic_utils.py
+++ b/diffsims/utils/generic_utils.py
@@ -84,7 +84,7 @@ def get_grid(sz, tpb=None):
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, cache=False, nopython=True)
+@numba.njit(parallel=True, fastmath=True, cache=False)
 def __toMesh2d(x0, x1, dx0, dx1, out):  # pragma: no cover
     for i0 in numba.prange(x0.size):
         X00 = x0[i0] * dx0[0]
@@ -95,7 +95,7 @@ def __toMesh2d(x0, x1, dx0, dx1, out):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(parallel=True, fastmath=True, cache=False, nopython=True)
+@numba.njit(parallel=True, fastmath=True, cache=False)
 def __toMesh3d(x0, x1, x2, dx0, dx1, dx2, out):  # pragma: no cover
     for i0 in numba.prange(x0.size):
         X00 = x0[i0] * dx0[0]

--- a/diffsims/utils/probe_utils.py
+++ b/diffsims/utils/probe_utils.py
@@ -250,7 +250,7 @@ class BesselProbe(ProbeFunction):
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def _bess(X, R, H, J, scale, out):  # pragma: no cover
     if scale.size == 1:
         for i in numba.prange(X.shape[0]):
@@ -271,7 +271,7 @@ def _bess(X, R, H, J, scale, out):  # pragma: no cover
 
 
 # Coverage: Numba code does not register when code is run
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+@numba.njit(parallel=True, fastmath=True)
 def _bessFT(X, R, s, eps, out):  # pragma: no cover
     for i in numba.prange(X.shape[0]):
         rad = X[i, 0] * X[i, 0] + X[i, 1] * X[i, 1]


### PR DESCRIPTION
#### Description of the change
Force no-python mode with Numba to silence deprecation warnings raised in 0.57.0. The warning can be seen e.g. in a recent [kikuchipy PR test check](https://github.com/pyxem/kikuchipy/actions/runs/5033677479/jobs/9028051247?pr=639#step:12:50).

Since this warning is displayed to users of kikuchipy with Numba >= v0.57.0, I'd like for this patch to be released immediately. I've therefore bumped the version to 0.5.2 and updated the changelog.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.