### PR TITLE
List explicit support for Python 3.11 and remove for 3.6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 
 
 #### Progress of the PR
-
 - [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
 - [ ] Unit tests with pytest for all lines
 - [ ] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,12 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install dependencies
-        run: pip install manifix
+        run: |
+          pip install manifix
 
       - name: Check MANIFEST.in file
-        run: python setup.py manifix
+        run: |
+          python setup.py manifix
 
   build-with-pip:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
@@ -37,13 +39,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, '3.10']
+        python-version: ['3.10', '3.11']
         include:
-          # Oldest supported version of main dependencies on Python 3.6
-          - os: ubuntu-20.04
-            python-version: 3.6
+          # Oldest supported version of main dependencies
+          - os: ubuntu-latest
+            python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.9.0 scipy==1.0 tqdm==4.9
+            DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.9.0 scipy==1.1 tqdm==4.9
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +78,8 @@ jobs:
           pytest --doctest-modules --doctest-continue-on-failure --ignore-glob=diffsims/tests/*
 
       - name: Run tests
-        run: pytest -n 2 --cov=diffsims --pyargs diffsims
+        run: |
+          pytest -n 2 --cov=diffsims --pyargs diffsims
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,11 +18,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 
@@ -36,14 +39,9 @@ jobs:
         python -m build
 
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Explicit support for Python 3.11.
 
 Changed
 -------
@@ -22,6 +23,7 @@ Deprecated
 
 Removed
 -------
+- Removed support for Python 3.6, leaving 3.7 as the oldest supported version.
 
 Fixed
 -----

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -13,7 +13,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build doc in all formats (HTML, PDF and ePub)
 formats:

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,11 @@ setup(
     long_description=open("README.rst").read(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         (
@@ -81,7 +81,7 @@ setup(
         "numpy              >= 1.17",
         "orix               >= 0.9",
         "psutil",
-        "scipy              >= 1.0",
+        "scipy              >= 1.1",
         "tqdm               >= 4.9",
         "transforms3d",
     ],


### PR DESCRIPTION
#### Description of the change
Same procedures as for https://github.com/pyxem/orix/pull/455.

Removed support for Python 3.6 because >= 3.7 should be enough. Had to bump oldest SciPy from 1.0 to 1.1 for Python 3.7.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.