### PR TITLE
Faster implementation for get_points_in_sphere() using ogrid

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -60,6 +60,11 @@
     },
     {
       "name":"Eirik Opheim"
+    },
+    {
+      "name":"Dieter Weber",
+      "orcid": "0000-0001-6635-9567",
+      "affiliation": "Jülich Research Centre, Ernst Ruska Centre"
     }
   ]
 }

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -23,6 +23,7 @@ credits = [
     "Tina Bergh",
     "Tomas Ostasevicius",
     "Eirik Opheim",
+    "Dieter Weber",
 ]
 license = "GPLv3+"
 maintainer = "Duncan Johnstone, Phillip Crout, Håkon Wiik Ånes"

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -455,11 +455,11 @@ def get_points_in_sphere(reciprocal_lattice, reciprocal_radius):
     limit = reciprocal_radius**2
     h_list, k_list, l_list = np.ogrid[-h_max:h_max + 1, -k_max:k_max + 1, -l_max:l_max + 1]
     full_shape = (2*h_max + 1, 2*k_max + 1, 2*l_max + 1)
-    
+
     h_vec = h_list[..., np.newaxis] * reciprocal_lattice.base[0]
     k_vec = k_list[..., np.newaxis] * reciprocal_lattice.base[1]
     l_vec = l_list[..., np.newaxis] * reciprocal_lattice.base[2]
-    
+
     vec = h_vec + k_vec + l_vec
     norm2 = np.sum(vec**2, axis=-1)
     select = norm2 < limit
@@ -467,7 +467,7 @@ def get_points_in_sphere(reciprocal_lattice, reciprocal_radius):
     k_select = np.broadcast_to(k_list, full_shape)[select]
     l_select = np.broadcast_to(l_list, full_shape)[select]
     spot_indices = np.stack((h_select, k_select, l_select), axis=-1)
-    
+
     cartesian_coordinates = vec[select]
     spot_distances = np.sqrt(norm2[select])
 

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -18,7 +18,6 @@
 
 import collections
 import math
-from functools import lru_cache
 
 import diffpy.structure
 import numpy as np


### PR DESCRIPTION
When profiling the performance of diffraction pattern simulation, most time was spent in this function.

This implementation runs more than three times faster since it reduces the calculation effort through broadcasting and re-uses coordinate and distance calculations.

Instead of using diffpy, it performs the equivalent transformation to cartesian and calculation of the norm directly to allow these optimizations.

#### Description of the change

Equivalent calculation using `numpy.ogrid()` and broadcasting to calculate hkl map, cartesian vectors, norm and selection to radius.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
  - Change should not change coverage
- [ ] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

Code style is dead link:
![image](https://github.com/pyxem/diffsims/assets/25689052/6df7d3e5-04af-45a4-96e7-ef8932abab3d)


#### Minimal example of the bug fix or new feature

![image](https://github.com/pyxem/diffsims/assets/25689052/eed0b8a2-5696-4885-a66c-c4b78b55e67e)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.