### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    # Version can be updated by running "pre-commit autoupdate"
+    rev: 24.3.0
+    hooks:
+      - id: black
+ci:
+  # Don't run automatically on PRs, instead add the comment
+  # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing
+  autofix_prs: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 Added
 -----
 - Explicit support for Python 3.11.
+- Added Pre-Commit for code formatting.
 
 Changed
 -------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -86,6 +86,10 @@ Please run the latest version of
 `black <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_ on
 your newly added and modified files prior to each PR.
 
+If this doesn't work for you, you can also use the Pre-commit CI to reformat your code
+on github by commenting "pre-commit autofix" on your PR.
+
+
 Run and write tests
 -------------------
 


### PR DESCRIPTION
#### Description of the change

Add support for Pre-commit for checking code style.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.