### PR TITLE
Remove Python 3.7 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.9.0 scipy==1.1 tqdm==4.9
+            DEPENDENCIES: diffpy.structure== 3.0.2 matplotlib==3.5 numpy==1.17.3 orix==0.9.0 scipy==1.8 tqdm==4.9
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - '*'
   workflow_dispatch:
-    workflow: '*'
 
 env:
   MPLBACKEND: agg
@@ -19,9 +18,11 @@ jobs:
     name: check manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -45,13 +46,13 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: diffpy.structure== 3.0.2 matplotlib==3.5 numpy==1.17.3 orix==0.9.0 scipy==1.8 tqdm==4.9
+            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.5 numpy==1.17.3 orix==0.9.0 scipy==1.8 tqdm==4.9
             LABEL: -oldest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         include:
           # Oldest supported version of main dependencies
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: diffpy.structure==3.0.0 matplotlib==3.3 numpy==1.17 orix==0.9.0 scipy==1.1 tqdm==4.9
             LABEL: -oldest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,7 @@ Deprecated
 
 Removed
 -------
-- Removed support for Python 3.6, leaving 3.7 as the oldest supported version.
-- Removed support for Python 3.7, leaving 3.8 as the oldest supported version.
+- Removed support for Python 3.6 and Python 3.7, leaving 3.7 as the oldest supported version.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Deprecated
 Removed
 -------
 - Removed support for Python 3.6, leaving 3.7 as the oldest supported version.
+- Removed support for Python 3.7, leaving 3.8 as the oldest supported version.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Deprecated
 
 Removed
 -------
-- Removed support for Python 3.6 and Python 3.7, leaving 3.7 as the oldest supported version.
+- Removed support for Python 3.6 and Python 3.7, leaving 3.8 as the oldest supported
+  version.
 
 Fixed
 -----

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     long_description=open("README.rst").read(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -74,13 +74,13 @@ setup(
     packages=find_packages(),
     extras_require=extra_feature_requirements,
     install_requires=[
-        "diffpy.structure   >= 3.0.0",  # First Python 3 support
+        "diffpy.structure   >= 3.0.2",
         "matplotlib         >= 3.3",
         "numba",
-        "numpy              >= 1.17",
+        "numpy              >= 1.17.3",
         "orix               >= 0.9",
         "psutil",
-        "scipy              >= 1.1",
+        "scipy              >= 1.8",
         "tqdm               >= 4.9",
         "transforms3d",
     ],


### PR DESCRIPTION
#### Description of the change
Remove python 3.7 support

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### Minimal example of the bug fix or new feature
```python
>>> from diffsims.utils import sim_utils
>>> # Your new feature...
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.