### PR TITLE
Prepare for 0.6rc1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Test files
-file_01.pickle
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -13,6 +13,11 @@
       "affiliation": "Norwegian University of Science and Technology"
     },
     {
+      "name":"Carter Francis",
+      "orcid": "0000-0003-2564-1851",
+      "affiliation": "University of Wisconsin Madison"
+    },
+    {
       "name":"Eric Prestat"
     },
     {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Removed
   version.
 - ``ReciprocalLatticePoint`` class; Use the ``ReciprocalLatticeVector`` class instead,
   which is an improved replacement.
+- ``StructureLibrary.from_crystal_systems()`` class method, which previously raised a
+  ``NotImplementedError``, but now will throw an ``AttributeError`` instead.
 
 2023-05-22 - version 0.5.2
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,15 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 this project tries its best to adhere to
 `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
-==========
+2024-05-12 - version 0.6.0
+==========================
 
 Added
 -----
 - Explicit support for Python 3.11.
 - Added Pre-Commit for code formatting.
-- Added deprecation tools for deprecating functions, parameters, methods, and properties.
+- Added deprecation tools for deprecating functions, parameters, methods, and
+  properties.
 
 Changed
 -------
@@ -23,6 +24,10 @@ Changed
 
 Deprecated
 ----------
+- ``get_hkl()``, ``get_highest_hkl()``, and ``get_equivalent_hkl()`` methods in the
+  crystallography module. Please use the following corresponding methods in the
+  ``ReciprocalLatticeVector`` class instead: ``from_highest_hkl()``,
+  ``from_min_dspacing()``, and ``symmetrise()``.
 
 Removed
 -------
@@ -30,9 +35,6 @@ Removed
   version.
 - ``ReciprocalLatticePoint`` class; Use the ``ReciprocalLatticeVector`` class instead,
   which is an improved replacement.
-
-Fixed
------
 
 2023-05-22 - version 0.5.2
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -1,29 +1,89 @@
-|build_status|_ |Coveralls|_ |docs|_ |pypi_version|_ |black|_ |doi|_
-
-.. |build_status| image:: https://github.com/pyxem/diffsims/workflows/build/badge.svg
-.. _build_status: https://github.com/pyxem/diffsims/actions
-
-.. |Coveralls| image:: https://coveralls.io/repos/github/pyxem/diffsims/badge.svg?branch=master
-.. _Coveralls: https://coveralls.io/github/pyxem/diffsims?branch=master
-
-.. |docs| image:: https://readthedocs.org/projects/diffsims/badge/?version=latest
-.. _docs: https://diffsims.readthedocs.io/en/latest
-
-.. |pypi_version| image:: https://img.shields.io/pypi/v/diffsims.svg?style=flat
-.. _pypi_version: https://pypi.org/project/diffsims/
-
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-.. _black: https://github.com/psf/black
-
-.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3337900.svg
-.. _doi: https://doi.org/10.5281/zenodo.3337900
-
 diffsims is an open-source Python library for simulating diffraction.
 
-If simulations performed using diffsims form a part of published work please
-cite the DOI at the top of this page. You can find demos in the `diffsims-demos
-<https://github.com/pyxem/diffsims-demos>`_ repository. See the `documentation
-<https://diffsims.readthedocs.io/en/latest/>`_ for installation instructions, the API
-reference, the changelog and more.
+The package is released under the GPL v3 license.
 
-diffsims is released under the GPL v3 license.
+.. |pypi_version| image:: https://img.shields.io/pypi/v/diffsims.svg?style=flat
+   :target: https://pypi.python.org/pypi/diffsims
+
+.. |conda| image:: https://img.shields.io/conda/vn/conda-forge/diffsims.svg?logo=conda-forge&logoColor=white
+   :target: https://anaconda.org/conda-forge/diffsims
+
+.. |build_status| image:: https://github.com/pyxem/diffsims/workflows/build/badge.svg
+   :target: https://github.com/pyxem/diffsims/actions/workflows/build.yml
+
+.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
+   :target: https://www.python.org/downloads/
+
+.. |Coveralls| image:: https://coveralls.io/repos/github/pyxem/diffsims/badge.svg?branch=main
+   :target: https://coveralls.io/github/pyxem/diffsims?branch=main
+
+.. |pypi_downloads| image:: https://img.shields.io/pypi/dm/diffsims.svg?label=PyPI%20downloads
+   :target: https://pypi.org/project/diffsims/
+
+.. |conda_downloads| image:: https://img.shields.io/conda/dn/conda-forge/diffsims.svg?label=Conda%20downloads
+   :target: https://anaconda.org/conda-forge/diffsims
+
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3337900.svg
+   :target: https://doi.org/10.5281/zenodo.3337900
+
+.. |GPLv3| image:: https://img.shields.io/github/license/pyxem/diffsims
+   :target: https://opensource.org/license/GPL-3.0
+
+.. |GH-issues| image:: https://img.shields.io/badge/GitHub-Issues-green?logo=github
+   :target: https://github.com/pyxem/diffsims/issues
+
+.. |docs| image:: https://readthedocs.org/projects/diffsims/badge/?version=latest
+   :target: https://diffsims.readthedocs.io/en/latest
+
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+
++----------------------+------------------------------------------------+
+| Deployment           | |pypi_version| |conda|                         |
++----------------------+------------------------------------------------+
+| Build status         | |build_status| |docs| |python|                 |
++----------------------+------------------------------------------------+
+| Metrics              | |Coveralls|                                    |
++----------------------+------------------------------------------------+
+| Activity             | |pypi_downloads| |conda_downloads|             |
++----------------------+------------------------------------------------+
+| Citation             | |doi|                                          |
++----------------------+------------------------------------------------+
+| License              | |GPLv3|                                        |
++----------------------+------------------------------------------------+
+| Community            | |GH-issues|                                    |
++----------------------+------------------------------------------------+
+| Formatter            | |black|                                        |
++----------------------+------------------------------------------------+
+
+Documentation
+-------------
+
+Refer to the `documentation <https://diffsims.readthedocs.io>`__ for detailed
+installation instructions, a user guide, a technical (API) reference, and the `changelog
+<https://diffsims.readthedocs.io/en/latest/changelog.html>`_.
+
+Installation
+------------
+
+diffsims can be installed with ``pip``::
+
+    pip install diffsims
+
+or ``conda``::
+
+    conda install diffsims -c conda-forge
+
+The source code is hosted in `GitHub <https://github.com/pyxem/diffsims>`_, and can also
+be downloaded from `PyPI <https://pypi.org/project/diffsims>`_ and
+`Anaconda <https://anaconda.org/conda-forge/diffsims>`_.
+
+Further details are available in the
+`installation guide
+<https://diffsims.readthedocs.io/en/latest/user/installation.html>`_.
+
+Citing diffsims
+---------------
+
+If simulations performed using diffsims form a part of published work please
+cite the DOI at the top of this page.

--- a/diffsims/__init__.py
+++ b/diffsims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/conftest.py
+++ b/diffsims/conftest.py
@@ -17,11 +17,16 @@
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
 from diffpy.structure import Atom, Lattice, Structure
+import matplotlib.pyplot as plt
 from orix.crystal_map import Phase
 import pytest
 
 from diffsims.crystallography import ReciprocalLatticeVector
 from diffsims.generators.diffraction_generator import DiffractionGenerator
+
+
+def pytest_sessionstart(session):
+    plt.rcParams["backend"] = "agg"
 
 
 @pytest.fixture

--- a/diffsims/conftest.py
+++ b/diffsims/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/conftest.py
+++ b/diffsims/conftest.py
@@ -26,7 +26,7 @@ from diffsims.generators.diffraction_generator import DiffractionGenerator
 
 @pytest.fixture
 def default_structure():
-    """An atomic structure represented using diffpy"""
+    """An atomic structure represented using diffpy."""
     latt = Lattice(3, 3, 5, 90, 90, 120)
     atom = Atom(atype="Ni", xyz=[0, 0, 0], lattice=latt)
     hexagonal_structure = Structure(atoms=[atom], lattice=latt)
@@ -109,3 +109,10 @@ def add_reciprocal_lattice_vector_al(doctest_namespace):
     )
     rlv = ReciprocalLatticeVector(phase, hkl=[[1, 1, 1], [2, 0, 0]])
     doctest_namespace["rlv"] = rlv
+
+
+@pytest.fixture(params=[("file_01")])
+def pickle_temp_file(tmpdir, request):
+    name = request.param
+    fname = tmpdir.join(name + ".pickle")
+    yield fname

--- a/diffsims/crystallography/__init__.py
+++ b/diffsims/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/get_hkl.py
+++ b/diffsims/crystallography/get_hkl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/crystallography/reciprocal_lattice_vector.py
+++ b/diffsims/crystallography/reciprocal_lattice_vector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/__init__.py
+++ b/diffsims/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/library_generator.py
+++ b/diffsims/generators/library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/rotation_list_generators.py
+++ b/diffsims/generators/rotation_list_generators.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
 from orix.quaternion.rotation import Rotation
-from orix.vector.neo_euler import AxAngle
 
 from diffsims.utils.sim_utils import uvtw_to_uvw
 from diffsims.generators.sphere_mesh_generators import (
@@ -168,7 +167,7 @@ def get_grid_around_beam_direction(beam_rotation, resolution, angular_range=(0, 
         np.arange(start=angular_range[0], stop=angular_range[1], step=resolution)
     )
     axes = np.repeat([[0, 0, 1]], angles.shape[0], axis=0)
-    in_plane_rotation = Rotation.from_neo_euler(AxAngle.from_axes_angles(axes, angles))
+    in_plane_rotation = Rotation.from_axes_angles(axes, angles)
 
     orix_grid = beam_rotation * in_plane_rotation
     rotation_list = get_list_from_orix(orix_grid, rounding=2)

--- a/diffsims/generators/sphere_mesh_generators.py
+++ b/diffsims/generators/sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/generators/zap_map_generator.py
+++ b/diffsims/generators/zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/__init__.py
+++ b/diffsims/libraries/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/diffraction_library.py
+++ b/diffsims/libraries/diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/libraries/structure_library.py
+++ b/diffsims/libraries/structure_library.py
@@ -81,36 +81,6 @@ class StructureLibrary:
         """
         return cls(identifiers, structures, orientations)
 
-    @classmethod
-    def from_crystal_systems(
-        cls, identifiers, structures, systems, resolution, equal="angle"
-    ):
-        """
-        Creates a structure library from crystal system derived orientation lists
-
-        Parameters
-        ----------
-        identifiers : list of strings/ints
-            A list of phase identifiers referring to different atomic structures.
-        structures : list of diffpy.structure.Structure objects.
-            A list of diffpy.structure.Structure objects describing the atomic
-            structure associated with each phase in the library.
-        systems : list
-            A list over indentifiers of crystal systems
-        resolution : float
-            resolution in degrees
-        equal : str
-            Default is 'angle'
-
-        Raises
-        ------
-        NotImplementedError:
-            "This function has been removed in version 0.3.0, in favour of creation from orientation lists"
-        """
-        raise NotImplementedError(
-            "This function has been removed in version 0.3.0, in favour of creation from orientation lists"
-        )
-
     def get_library_size(self, to_print=False):
         """
         Returns the the total number of orientations in the

--- a/diffsims/libraries/vector_library.py
+++ b/diffsims/libraries/vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/__init__.py
+++ b/diffsims/pattern/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -26,6 +26,6 @@ credits = [
     "Eirik Opheim",
 ]
 license = "GPLv3+"
-maintainer = "Duncan Johnstone, Phillip Crout, Håkon Wiik Ånes"
+maintainer = "Duncan Johnstone, Phillip Crout, Håkon Wiik Ånes, Carter Francis"
 email = "pyxem.team@gmail.com"
 status = "Development"

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.6.0"
+version = "0.6rc1"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2024, The diffsims developers"
 # Initial committer first, then listed by line additions
@@ -7,6 +7,7 @@ credits = [
     "Duncan Johnstone",
     "Phillip Crout",
     "Håkon Wiik Ånes",
+    "Carter Francis",
     "Eric Prestat",
     "Rob Tovey",
     "Simon Høgås",

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,7 +1,7 @@
 name = "diffsims"
-version = "0.6.dev0"
+version = "0.6.0"
 author = "Duncan Johnstone, Phillip Crout"
-copyright = "Copyright 2017-2023, The diffsims developers"
+copyright = "Copyright 2017-2024, The diffsims developers"
 # Initial committer first, then listed by line additions
 credits = [
     "Duncan Johnstone",

--- a/diffsims/sims/__init__.py
+++ b/diffsims/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/sims/diffraction_simulation.py
+++ b/diffsims/sims/diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/__init__.py
+++ b/diffsims/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_factor.py
+++ b/diffsims/structure_factor/atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/structure_factor/structure_factor.py
+++ b/diffsims/structure_factor/structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/__init__.py
+++ b/diffsims/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/__init__.py
+++ b/diffsims/tests/crystallography/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_get_hkl.py
+++ b/diffsims/tests/crystallography/test_get_hkl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
+++ b/diffsims/tests/crystallography/test_reciprocal_lattice_vector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/__init__.py
+++ b/diffsims/tests/generators/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_diffraction_generator.py
+++ b/diffsims/tests/generators/test_diffraction_generator.py
@@ -248,17 +248,17 @@ class TestDiffractionCalculatorAtomic:
 
         np.testing.assert_allclose(diffraction1, diffraction2, 1e-6, 1e-6)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_mode(self, diffraction_calculator_atomic, local_structure):
-        diffraction = diffraction_calculator_atomic.calculate_ed_data(
-            local_structure, probe, 1, mode="other"
-        )
+        with pytest.raises(NotImplementedError):
+            _ = diffraction_calculator_atomic.calculate_ed_data(
+                local_structure, probe, 1, mode="other"
+            )
 
-    @pytest.mark.xfail(raises=ValueError, strict=True)
     def test_bad_ZERO(self, diffraction_calculator_atomic, local_structure):
-        _ = diffraction_calculator_atomic.calculate_ed_data(
-            local_structure, probe, 1, ZERO=-1
-        )
+        with pytest.raises(ValueError):
+            _ = diffraction_calculator_atomic.calculate_ed_data(
+                local_structure, probe, 1, ZERO=-1
+            )
 
 
 @pytest.mark.parametrize("scattering_param", ["lobato", "xtables"])
@@ -266,18 +266,18 @@ def test_param_check(scattering_param):
     generator = DiffractionGenerator(300, scattering_params=scattering_param)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_invalid_scattering_params():
     scattering_param = "_empty"
-    generator = DiffractionGenerator(300, scattering_params=scattering_param)
+    with pytest.raises(NotImplementedError):
+        _ = DiffractionGenerator(300, scattering_params=scattering_param)
 
 
-@pytest.mark.xfail(faises=NotImplementedError)
 def test_invalid_shape_model():
-    generator = DiffractionGenerator(300, shape_factor_model="dracula")
+    with pytest.raises(NotImplementedError):
+        _ = DiffractionGenerator(300, shape_factor_model="dracula")
 
 
 @pytest.mark.parametrize("shape", [(10, 20), (20, 10)])
 def test_param_check_atomic(shape):
     detector = [np.linspace(-1, 1, s) for s in shape]
-    generator = AtomicDiffractionGenerator(300, detector, True)
+    _ = AtomicDiffractionGenerator(300, detector, True)

--- a/diffsims/tests/generators/test_library_generator.py
+++ b/diffsims/tests/generators/test_library_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_rotation_list_generator.py
+++ b/diffsims/tests/generators/test_rotation_list_generator.py
@@ -94,6 +94,6 @@ def test_get_beam_directions_grid_size(crystal_system, desired_size):
     assert grid.shape[0] == desired_size
 
 
-@pytest.mark.xfail()
 def test_invalid_mesh_beam_directions():
-    _ = get_beam_directions_grid("cubic", 10, mesh="invalid")
+    with pytest.raises(NotImplementedError):
+        _ = get_beam_directions_grid("cubic", 10, mesh="invalid")

--- a/diffsims/tests/generators/test_simulation_generator.py
+++ b/diffsims/tests/generators/test_simulation_generator.py
@@ -126,6 +126,13 @@ class TestDiffractionCalculator:
         assert diffraction_calculator.approximate_precession == True
         assert diffraction_calculator.minimum_intensity == 1e-20
 
+    def test_repr(self, diffraction_calculator):
+        assert repr(diffraction_calculator) == (
+            "SimulationGenerator(accelerating_voltage=300, "
+            "scattering_params=lobato, "
+            "approximate_precession=True)"
+        )
+
     def test_matching_results(
         self, diffraction_calculator: SimulationGenerator, local_structure
     ):
@@ -245,9 +252,7 @@ def test_multiphase_multirotation_simulation():
     big_silicon = make_phase(10)
     rot = Rotation.from_euler([[0, 0, 0], [0.1, 0.1, 0.1]])
     rot2 = Rotation.from_euler([[0, 0, 0], [0.1, 0.1, 0.1], [0.2, 0.2, 0.2]])
-    sim = generator.calculate_diffraction2d(
-        [silicon, big_silicon], rotation=[rot, rot2]
-    )
+    _ = generator.calculate_diffraction2d([silicon, big_silicon], rotation=[rot, rot2])
 
 
 def test_multiphase_multirotation_simulation_error():
@@ -255,25 +260,24 @@ def test_multiphase_multirotation_simulation_error():
     silicon = make_phase(5)
     big_silicon = make_phase(10)
     rot = Rotation.from_euler([[0, 0, 0], [0.1, 0.1, 0.1]])
-    rot2 = Rotation.from_euler([[0, 0, 0], [0.1, 0.1, 0.1], [0.2, 0.2, 0.2]])
+    _ = Rotation.from_euler([[0, 0, 0], [0.1, 0.1, 0.1], [0.2, 0.2, 0.2]])
     with pytest.raises(ValueError):
-        sim = generator.calculate_diffraction2d([silicon, big_silicon], rotation=[rot])
+        _ = generator.calculate_diffraction2d([silicon, big_silicon], rotation=[rot])
 
 
 @pytest.mark.parametrize("scattering_param", ["lobato", "xtables"])
 def test_param_check(scattering_param):
-    generator = SimulationGenerator(300, scattering_params=scattering_param)
+    _ = SimulationGenerator(300, scattering_params=scattering_param)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_invalid_scattering_params():
-    scattering_param = "_empty"
-    generator = SimulationGenerator(300, scattering_params=scattering_param)
+    with pytest.raises(NotImplementedError):
+        _ = SimulationGenerator(300, scattering_params="_empty")
 
 
-@pytest.mark.xfail(faises=NotImplementedError)
 def test_invalid_shape_model():
-    generator = SimulationGenerator(300, shape_factor_model="dracula")
+    with pytest.raises(NotImplementedError):
+        _ = SimulationGenerator(300, shape_factor_model="dracula")
 
 
 def test_same_simulation_results():

--- a/diffsims/tests/generators/test_sphere_mesh_generators.py
+++ b/diffsims/tests/generators/test_sphere_mesh_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/generators/test_zap_map_generator.py
+++ b/diffsims/tests/generators/test_zap_map_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/__init__.py
+++ b/diffsims/tests/library/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_diffraction_library.py
+++ b/diffsims/tests/library/test_diffraction_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_diffraction_library.py
+++ b/diffsims/tests/library/test_diffraction_library.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import numpy as np
 import pytest
 
@@ -58,10 +56,9 @@ def test_get_library_small_offset(get_library):
     assert np.allclose(alpha, beta)
 
 
-def test_library_io(get_library):
-    get_library.pickle_library("file_01.pickle")
-    loaded_library = load_DiffractionLibrary("file_01.pickle", safety=True)
-    os.remove("file_01.pickle")
+def test_library_io(get_library, pickle_temp_file):
+    get_library.pickle_library(pickle_temp_file)
+    loaded_library = load_DiffractionLibrary(pickle_temp_file, safety=True)
     # We can't check that the entire libraries are the same as the memory
     # location of the 'Sim' changes
     for i in range(len(get_library["Phase"]["orientations"])):
@@ -96,7 +93,7 @@ def test_unknown_library_entry(get_library):
         )
 
 
-def test_unsafe_loading(get_library):
+def test_unsafe_loading(get_library, pickle_temp_file):
     with pytest.raises(RuntimeError, match="Unpickling is risky, turn safety to True "):
-        get_library.pickle_library("file_01.pickle")
-        _ = load_DiffractionLibrary("file_01.pickle")
+        get_library.pickle_library(pickle_temp_file)
+        _ = load_DiffractionLibrary(pickle_temp_file)

--- a/diffsims/tests/library/test_structure_library.py
+++ b/diffsims/tests/library/test_structure_library.py
@@ -44,16 +44,6 @@ def test_from_orientations_method():
     np.testing.assert_equal(library.struct_lib["b"], (2, 4))
 
 
-@pytest.mark.xfail(reason="Functionality removed")
-def test_from_systems_methods():
-    identifiers = ["a", "b"]
-    structures = [1, 2]
-    systems = ["cubic", "hexagonal"]
-    library = StructureLibrary.from_crystal_systems(
-        identifiers, structures, systems, resolution=2
-    )
-
-
 @pytest.mark.parametrize(
     "identifiers, structures, orientations",
     [
@@ -61,6 +51,6 @@ def test_from_systems_methods():
         (["a"], [1], [3, 4]),
     ],
 )
-@pytest.mark.xfail(raises=ValueError)
 def test_constructor_parameter_validation_errors(identifiers, structures, orientations):
-    StructureLibrary(identifiers, structures, orientations)
+    with pytest.raises(ValueError):
+        _ = StructureLibrary(identifiers, structures, orientations)

--- a/diffsims/tests/library/test_structure_library.py
+++ b/diffsims/tests/library/test_structure_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_vector_library.py
+++ b/diffsims/tests/library/test_vector_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/library/test_vector_library.py
+++ b/diffsims/tests/library/test_vector_library.py
@@ -17,7 +17,6 @@
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-import os
 import numpy as np
 
 from diffsims.generators.library_generator import (
@@ -38,10 +37,9 @@ def get_library(default_structure):
     return vlg.get_vector_library(0.5)
 
 
-def test_library_io(get_library):
-    get_library.pickle_library("file_01.pickle")
-    loaded_library = load_VectorLibrary("file_01.pickle", safety=True)
-    os.remove("file_01.pickle")
+def test_library_io(get_library, pickle_temp_file):
+    get_library.pickle_library(pickle_temp_file)
+    loaded_library = load_VectorLibrary(pickle_temp_file, safety=True)
     # we can't check that the entire libraries are the same as the memory
     # location of the 'Sim' changes
     np.testing.assert_allclose(
@@ -52,13 +50,13 @@ def test_library_io(get_library):
     )
 
 
-@pytest.mark.xfail(raises=RuntimeError)
-def test_unsafe_loading(get_library):
-    get_library.pickle_library("file_01.pickle")
-    loaded_library = load_VectorLibrary("file_01.pickle")
+def test_unsafe_loading(get_library, pickle_temp_file):
+    get_library.pickle_library(pickle_temp_file)
+    with pytest.raises(RuntimeError):
+        _ = load_VectorLibrary(pickle_temp_file)
 
 
 def test_generate_lookup_table(default_structure):
     lattice = default_structure.lattice.reciprocal()
-    table = _generate_lookup_table(lattice, 0.5, unique=True)
-    table = _generate_lookup_table(lattice, 0.5, unique=False)
+    _ = _generate_lookup_table(lattice, 0.5, unique=True)
+    _ = _generate_lookup_table(lattice, 0.5, unique=False)

--- a/diffsims/tests/patterns/__init__.py
+++ b/diffsims/tests/patterns/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -120,13 +120,13 @@ class TestDeadPixel:
         z1 = add_dead_pixels(pattern, fraction=fraction)
         assert np.sum(z1 == 0) == 6  # we should have 6 dead pixels!
 
-    @pytest.mark.xfail(strict=True)
     def test_bad_kwarg_choices_a(self, pattern):
-        _ = add_dead_pixels(pattern, n=None, fraction=None)
+        with pytest.raises(ValueError):
+            _ = add_dead_pixels(pattern, n=None, fraction=None)
 
-    @pytest.mark.xfail(strict=True)
     def test_bad_kwarg_choices_b(self, pattern):
-        _ = add_dead_pixels(pattern, n=6, fraction=0.2)
+        with pytest.raises(ValueError):
+            _ = add_dead_pixels(pattern, n=6, fraction=0.2)
 
 
 class TestDetectorGainOffset:

--- a/diffsims/tests/patterns/test_detector_functions.py
+++ b/diffsims/tests/patterns/test_detector_functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/__init__.py
+++ b/diffsims/tests/sims/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/sims/test_diffraction_simulation.py
+++ b/diffsims/tests/sims/test_diffraction_simulation.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -86,6 +87,7 @@ def profile_simulation():
 
 def test_plot_profile_simulation(profile_simulation):
     profile_simulation.get_plot()
+    plt.close()
 
 
 class TestDiffractionSimulation:
@@ -320,4 +322,6 @@ class TestDiffractionSimulation:
             intensities=np.array([3.0, 5.0, 2.0]),
             calibration=[1, 2],
         )
-        ax, sp = short_sim.plot(units=units_in, show_labels=True)
+        _ = short_sim.plot(units=units_in, show_labels=True)
+
+        plt.close()

--- a/diffsims/tests/simulations/test_simulations1d.py
+++ b/diffsims/tests/simulations/test_simulations1d.py
@@ -15,11 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
-import matplotlib.pyplot as plt
-import pytest
 
-from orix.crystal_map import Phase
+import matplotlib.pyplot as plt
 import numpy as np
+from orix.crystal_map import Phase
+import pytest
 
 from diffsims.tests.generators.test_simulation_generator import make_phase
 from diffsims.simulations import Simulation1D
@@ -57,8 +57,10 @@ class TestSingleSimulation:
     @pytest.mark.parametrize("with_labels", [True, False])
     def test_plot(self, simulation1d, annotate, ax, with_labels):
         if ax == "new":
-            fig, ax = plt.subplots()
-        fig = simulation1d.plot(annotate_peaks=annotate, ax=ax, with_labels=with_labels)
+            _, ax = plt.subplots()
+        _ = simulation1d.plot(annotate_peaks=annotate, ax=ax, with_labels=with_labels)
+
+        plt.close()
 
     def test_repr(self, simulation1d):
         assert simulation1d.__repr__() == "Simulation1D(name: Al, wavelength: 0.025)"

--- a/diffsims/tests/simulations/test_simulations2d.py
+++ b/diffsims/tests/simulations/test_simulations2d.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import pytest
-
 from diffpy.structure import Structure, Atom, Lattice
+import matplotlib.pyplot as plt
+import numpy as np
 from orix.crystal_map import Phase
 from orix.quaternion import Rotation
+import pytest
 
 from diffsims.simulations import Simulation2D
 from diffsims.generators.simulation_generator import SimulationGenerator
@@ -80,6 +80,7 @@ class TestSingleSimulation:
 
     def test_plot(self, single_simulation):
         single_simulation.plot()
+        plt.close()
 
     def test_num_rotations(self, single_simulation):
         assert single_simulation._num_rotations() == 1
@@ -245,9 +246,11 @@ class TestSinglePhaseMultiSimulation:
 
     def test_plot(self, multi_simulation):
         multi_simulation.plot()
+        plt.close()
 
     def test_plot_rotation(self, multi_simulation):
         multi_simulation.plot_rotations()
+        plt.close()
 
     def test_iter(self, multi_simulation):
         multi_simulation.phase_index = 0
@@ -370,8 +373,11 @@ class TestMultiPhaseMultiSimulation:
             calibration=0.1,
         )
 
+        plt.close()
+
     def test_plot_rotation(self, multi_simulation):
         multi_simulation.plot_rotations()
+        plt.close()
 
     def test_iter(self, multi_simulation):
         multi_simulation.phase_index = 0

--- a/diffsims/tests/structure_factor/__init__.py
+++ b/diffsims/tests/structure_factor/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_atomic_scattering_parameters.py
+++ b/diffsims/tests/structure_factor/test_atomic_scattering_parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/structure_factor/test_structure_factor.py
+++ b/diffsims/tests/structure_factor/test_structure_factor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/__init__.py
+++ b/diffsims/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
+++ b/diffsims/tests/utils/test_atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_discretise_utils.py
+++ b/diffsims/tests/utils/test_discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_discretise_utils.py
+++ b/diffsims/tests/utils/test_discretise_utils.py
@@ -62,14 +62,10 @@ def test_getA(Z, returnFunc):
         assert len(a) == len(b)
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_2_atoms_getA():
-    get_atoms(np.array([0, 1]))
-
-
-@pytest.mark.xfail(raises=ValueError)
-def test_max_atom_getA():
-    get_atoms("Es")
+@pytest.mark.parametrize("atoms", [np.array([0, 1]), "Es"])
+def tests_get_atoms_raises(atoms):
+    with pytest.raises(ValueError):
+        get_atoms(atoms)
 
 
 @pytest.mark.parametrize(
@@ -82,13 +78,7 @@ def test_max_atom_getA():
 )
 def test_rebin(r):
     x = [np.linspace(0, 1, 10), np.linspace(0, 1, 21), np.linspace(0, 1, 32)]
-    loc = np.concatenate(
-        [
-            0 * np.linspace(0, 1, 500)[:, None],
-        ]
-        * 3,
-        axis=1,
-    )
+    loc = np.concatenate([0 * np.linspace(0, 1, 500)[:, None]] * 3, axis=1)
     k = 1
     mem = 1e5
     rebin(x, loc, r, k, mem)

--- a/diffsims/tests/utils/test_fourier_transform.py
+++ b/diffsims/tests/utils/test_fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_fourier_transform.py
+++ b/diffsims/tests/utils/test_fourier_transform.py
@@ -206,9 +206,9 @@ def test_DFT(rX, rY):
         np.testing.assert_allclose(f, IFT(g, axes=axes), 1e-5, 1e-5)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_fail_DFT():
-    get_DFT()
+    with pytest.raises(ValueError):
+        get_DFT()
 
 
 @pytest.mark.parametrize(

--- a/diffsims/tests/utils/test_generic_utils.py
+++ b/diffsims/tests/utils/test_generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_kinematic_simulation_utils.py
+++ b/diffsims/tests/utils/test_kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_mask_utils.py
+++ b/diffsims/tests/utils/test_mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_probe_utils.py
+++ b/diffsims/tests/utils/test_probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_probe_utils.py
+++ b/diffsims/tests/utils/test_probe_utils.py
@@ -85,10 +85,10 @@ def _random_array(shape, n=0):
     return x.reshape(shape)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_null_probe():
     p = ProbeFunction()
-    p(1)
+    with pytest.raises(NotImplementedError):
+        p(1)
 
 
 @pytest.fixture(params=[(10, 11, 12)])

--- a/diffsims/tests/utils/test_ring_pattern_utils.py
+++ b/diffsims/tests/utils/test_ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -114,25 +114,25 @@ def test_kinematic_simulator_xtables_scattering_params():
     )
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_kinematic_simulator_invalid_scattering_params():
     atomic_coordinates = np.asarray([[0, 0, 0]])  # structure.cart_coords
-    sim = simulate_kinematic_scattering(
-        atomic_coordinates,
-        "Si",
-        300.0,
-        simulation_size=32,
-        illumination="gaussian_probe",
-        scattering_params="_empty",
-    )
+    with pytest.raises(NotImplementedError):
+        simulate_kinematic_scattering(
+            atomic_coordinates,
+            "Si",
+            300.0,
+            simulation_size=32,
+            illumination="gaussian_probe",
+            scattering_params="_empty",
+        )
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_kinematic_simulator_invalid_illumination():
     atomic_coordinates = np.asarray([[0, 0, 0]])  # structure.cart_coords
-    sim = simulate_kinematic_scattering(
-        atomic_coordinates, "Si", 300.0, simulation_size=32, illumination="gaussian"
-    )
+    with pytest.raises(ValueError):
+        simulate_kinematic_scattering(
+            atomic_coordinates, "Si", 300.0, simulation_size=32, illumination="gaussian"
+        )
 
 
 @pytest.mark.parametrize(

--- a/diffsims/tests/utils/test_vector_utils.py
+++ b/diffsims/tests/utils/test_vector_utils.py
@@ -19,8 +19,7 @@
 import numpy as np
 import pytest
 
-from diffsims.utils.vector_utils import get_angle_cartesian
-from diffsims.utils.vector_utils import get_angle_cartesian_vec
+from diffsims.utils.vector_utils import get_angle_cartesian, get_angle_cartesian_vec
 
 
 @pytest.mark.parametrize(
@@ -47,6 +46,6 @@ def test_get_angle_cartesian_vec(a, b, expected_angles):
     np.testing.assert_allclose(angles, expected_angles)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_get_angle_cartesian_vec_input_validation():
-    get_angle_cartesian_vec(np.empty((2, 3)), np.empty((5, 3)))
+    with pytest.raises(ValueError):
+        get_angle_cartesian_vec(np.empty((2, 3)), np.empty((5, 3)))

--- a/diffsims/tests/utils/test_vector_utils.py
+++ b/diffsims/tests/utils/test_vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/__init__.py
+++ b/diffsims/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/_deprecated.py
+++ b/diffsims/utils/_deprecated.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_diffraction_generator_utils.py
+++ b/diffsims/utils/atomic_diffraction_generator_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/atomic_scattering_params.py
+++ b/diffsims/utils/atomic_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -96,7 +96,7 @@ def get_atoms(Z, returnFunc=True, dtype=FTYPE):
         Z = Z.astype(int)
     Z = unique(Z)
     if Z.size > 1:
-        raise ValueError("Only 1 atom can generated at once")
+        raise ValueError("Only 1 atom can be generated at once")
     else:
         Z = Z[0]
     if Z == 0:

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/fourier_transform.py
+++ b/diffsims/utils/fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/generic_utils.py
+++ b/diffsims/utils/generic_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/kinematic_simulation_utils.py
+++ b/diffsims/utils/kinematic_simulation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/lobato_scattering_params.py
+++ b/diffsims/utils/lobato_scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/mask_utils.py
+++ b/diffsims/utils/mask_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/probe_utils.py
+++ b/diffsims/utils/probe_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/ring_pattern_utils.py
+++ b/diffsims/utils/ring_pattern_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/scattering_params.py
+++ b/diffsims/utils/scattering_params.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/shape_factor_models.py
+++ b/diffsims/utils/shape_factor_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/sim_utils.py
+++ b/diffsims/utils/sim_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/diffsims/utils/vector_utils.py
+++ b/diffsims/utils/vector_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [tool:pytest]
 addopts = -ra
 doctest_optionflags = NORMALIZE_WHITESPACE
+filterwarnings =
+     # From setuptools
+     ignore:Deprecated call to \`pkg_resources:DeprecationWarning
+     ignore:pkg_resources is deprecated as an API:DeprecationWarning
 testpaths =
      diffsims/tests/
      # Docstring tests (examples)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2023 The diffsims developers
+# Copyright 2017-2024 The diffsims developers
 #
 # This file is part of diffsims.
 #


### PR DESCRIPTION
#### Description of the change

Release prep:
* Bump version to release candidate 0.6rc1
* Add @CSSFrancis to package credits
* Update README to use format in orix
* Update license year to 2024

Other changes:
* Actually remove the class method `StructureLibrary.from_crystal_systems()`. The method previously threw a NotImplementedError, but will now throw an AttributeError. Mentioned in the changelog under *Removed*.
* Replaced deprecated call to `Rotation.from_neo_euler()` with `Rotation.from_axes_angles()`.

I've cleaned up the test suite a bit:
* Replaced most uses of `xfail(error)` with `with pytest.raises(error):`. To me, it seems like best practice is to use the latter when we intentionally raise errors in the code, while the former is mostly used as a temporary measure for bugs that will be fixed.
* Silenced some warnings by making pytest ignoring them
* Close most of "opened" Matplotlib plots in tests using `plt.close()` (silencing a warning of > 20 open plots from Matplotlib)
* Yield a temporary pickle file to tests via fixture, removing the need for manually removing the file in a test

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)
- [x] Wait for #209

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.