### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,15 +7,14 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 this project tries its best to adhere to
 `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-2024-05-12 - version 0.6.0
+2024-06-06 - version 0.6.0
 ==========================
 
 Added
 -----
 - Explicit support for Python 3.11.
-- Added Pre-Commit for code formatting.
-- Added deprecation tools for deprecating functions, parameters, methods, and
-  properties.
+- pre-commit configuration file for code formatting.
+- Deprecation tools for deprecating functions, parameters, methods, and properties.
 
 Changed
 -------

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -1,5 +1,5 @@
 name = "diffsims"
-version = "0.6rc1"
+version = "0.6.0"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2024, The diffsims developers"
 # Initial committer first, then listed by line additions

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -65,8 +65,8 @@ install diffsims from source is to clone the repository from `GitHub
     pip install --editable .
 
 The source can also be downloaded as tarballs or zip archives via links like
-`https://github.com/pyxem/diffsims/archive/v<major.minor.patch>/diffsims-<major.minor.patch>.tar.gz`_,
-where the version ``<major.minor.patch>`` can be e.g. ``0.5.1``, and ``tar.gz`` can be
-exchanged with ``zip``.
+``https://github.com/pyxem/diffsims/archive/v<major.minor.patch>/
+diffsims-<major.minor.patch>.tar.gz``, where the version ``<major.minor.patch>`` can be
+e.g. ``0.5.1``, and ``tar.gz`` can be exchanged with ``zip``.
 
 .. _https://github.com/pyxem/diffsims/archive/v<major.minor.patch>/diffsims-<major.minor.patch>.tar.gz: https://github.com/pyxem/diffsims/archive/v<major.minor.patch>/diffsims-<major.minor.patch>.tar.gz

--- a/doc/user/related_projects.rst
+++ b/doc/user/related_projects.rst
@@ -7,7 +7,9 @@ Related, open-source projects that users of diffsims might find useful:
 - `pyxem <https://pyxem.readthedocs.io/en/stable>`_: Python library for
   multi-dimensional diffraction microscopy. Uses diffsims.
 - `orix <https://orix.readthedocs.io/en/stable>`_: Python library for handling crystal
-  orientation mapping data. diffsims uses on orix.
+  orientation mapping data. diffsims uses orix.
 - `kikuchipy <https://kikuchipy.org/en/stable>`_: Python library for processing,
   simulating and indexing of electron backscatter diffraction (EBSD) patterns. Uses
   diffsims.
+- `abtem <https://abtem.github.io/doc/intro.html>`_: Flexible Python package for
+  simulating transmission electron microscopy experiments from first principles.


### PR DESCRIPTION
#### Description of the change

Prepares for 0.6.0 release.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.