### PR TITLE
Deprecation: Fix ptp --> np.ptp for numpy 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 
 Fixed
 -----
+- Numpy 2.0.0 compatibility in (#228).
 
 2024-06-06 - version 0.6.0
 ==========================

--- a/diffsims/constants.py
+++ b/diffsims/constants.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+#  TODO: Remove this section when minimum numpy version is 1.25.0
+if np.__version__ >= "1.25.0":
+    from numpy.exceptions import VisibleDeprecationWarning
+else:
+    VisibleDeprecationWarning = np.VisibleDeprecationWarning

--- a/diffsims/generators/diffraction_generator.py
+++ b/diffsims/generators/diffraction_generator.py
@@ -527,7 +527,7 @@ class AtomicDiffractionGenerator:
 
         # Add z-coordinate
         z_range = max(
-            z_range, coordinates[:, -1].ptp()
+            z_range, np.ptp(coordinates[:, -1])
         )  # enforce minimal resolution in reciprocal space
         x = [
             self.detector[0],

--- a/diffsims/simulations/simulation2d.py
+++ b/diffsims/simulations/simulation2d.py
@@ -253,6 +253,7 @@ class Simulation2D:
             return self.rotations.size
 
     def deepcopy(self):
+
         return copy.deepcopy(self)
 
     def _get_transformed_coordinates(

--- a/diffsims/tests/crystallography/test_get_hkl.py
+++ b/diffsims/tests/crystallography/test_get_hkl.py
@@ -27,11 +27,7 @@ from diffsims.crystallography import (
     get_hkl,
     ReciprocalLatticeVector,
 )
-
-if np.__version__ >= "2.0.0":
-    from numpy.exceptions import VisibleDeprecationWarning
-else:
-    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+from diffsims.constants import VisibleDeprecationWarning
 
 
 class TestGetHKL:

--- a/diffsims/tests/crystallography/test_get_hkl.py
+++ b/diffsims/tests/crystallography/test_get_hkl.py
@@ -28,12 +28,17 @@ from diffsims.crystallography import (
     ReciprocalLatticeVector,
 )
 
+if np.__version__ >= "2.0.0":
+    from numpy.exceptions import VisibleDeprecationWarning
+else:
+    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+
 
 class TestGetHKL:
     @pytest.mark.parametrize("highest_hkl, n", [([1, 2, 3], 105), ([1, 1, 1], 27)])
     def test_get_hkl(self, highest_hkl, n):
         highest_hkl = np.array(highest_hkl)
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl = get_hkl(highest_hkl)
         assert np.allclose(hkl.max(axis=0), highest_hkl)
         assert np.allclose(hkl.min(axis=0), -highest_hkl)
@@ -52,7 +57,7 @@ class TestGetHKL:
         "d, hkl", [(0.5, [6, 6, 21]), (1, [3, 3, 11]), (1.5, [2, 2, 7])]
     )
     def test_get_highest_hkl(self, silicon_carbide_phase, d, hkl):
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl_out = get_highest_hkl(
                 silicon_carbide_phase.structure.lattice, min_dspacing=d
             )
@@ -64,7 +69,7 @@ class TestGetHKL:
 
     def test_get_equivalent_hkl(self):
         phase_225 = Phase(space_group=225)
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl1 = get_equivalent_hkl(
                 [1, 1, 1], operations=phase_225.point_group, unique=True
             )
@@ -86,12 +91,12 @@ class TestGetHKL:
         g1 = ReciprocalLatticeVector(phase_225, hkl=[1, 1, 1])
         assert np.allclose(g1.symmetrise().hkl, hkl1.data)
 
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl2 = get_equivalent_hkl([1, 1, 1], operations=phase_225.point_group)
         assert hkl2.shape[0] == g1.symmetrise().size * 6 == 48
 
         phase_186 = Phase(space_group=186)
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl3, mult3 = get_equivalent_hkl(
                 [2, 2, 0],
                 operations=phase_186.point_group,
@@ -102,7 +107,7 @@ class TestGetHKL:
         assert mult3 == g3.symmetrise().size == 12
         assert np.allclose(hkl3.data[:2], [[2, 2, 0], [-2.7321, 0.7321, 0]], atol=1e-4)
 
-        with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             hkl4, mult4 = get_equivalent_hkl(
                 Vector3d([[2, 2, 0], [4, 0, 0]]),
                 phase_186.point_group,

--- a/diffsims/tests/utils/test_deprecation.py
+++ b/diffsims/tests/utils/test_deprecation.py
@@ -5,6 +5,11 @@ import pytest
 
 from diffsims.utils._deprecated import deprecated, deprecated_argument
 
+if np.__version__ >= "2.0.0":
+    from numpy.exceptions import VisibleDeprecationWarning
+else:
+    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+
 
 class TestDeprecationWarning:
     def test_deprecation_since(self):
@@ -18,7 +23,7 @@ class TestDeprecationWarning:
             """Some docstring."""
             return n + 1
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo(4) == 5
         desired_msg = (
             "Function `foo()` is deprecated and will be removed in version 0.8. Use "
@@ -41,7 +46,7 @@ class TestDeprecationWarning:
             """
             return n + 2
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+        with pytest.warns(VisibleDeprecationWarning) as record2:
             assert foo2(4) == 6
         desired_msg2 = "Function `foo2()` is deprecated."
         assert str(record2[0].message) == desired_msg2
@@ -58,7 +63,7 @@ class TestDeprecationWarning:
         def foo(n):
             return n + 1
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo(4) == 5
         desired_msg = (
             "Function `foo()` is deprecated and will be removed in version 0.8. Use "
@@ -79,7 +84,7 @@ class TestDeprecationWarning:
         def foo(n):
             return n + 1
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo(4) == 5
         desired_msg = (
             "Function `foo()` is deprecated and will be removed in version 0.8. Use "
@@ -118,7 +123,7 @@ class TestDeprecateArgument:
             assert my_foo.bar_arg(b=1) == {"b": 1}
 
         # Warns
-        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+        with pytest.warns(VisibleDeprecationWarning) as record2:
             assert my_foo.bar_arg(a=2) == {"a": 2}
         assert str(record2[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "
@@ -127,7 +132,7 @@ class TestDeprecateArgument:
         )
 
         # Warns with alternative
-        with pytest.warns(np.VisibleDeprecationWarning) as record3:
+        with pytest.warns(VisibleDeprecationWarning) as record3:
             assert my_foo.bar_arg_alt(a=3) == {"b": 3}
         assert str(record3[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "

--- a/diffsims/tests/utils/test_deprecation.py
+++ b/diffsims/tests/utils/test_deprecation.py
@@ -1,14 +1,10 @@
 import warnings
 
-import numpy as np
 import pytest
 
 from diffsims.utils._deprecated import deprecated, deprecated_argument
 
-if np.__version__ >= "2.0.0":
-    from numpy.exceptions import VisibleDeprecationWarning
-else:
-    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+from diffsims.constants import VisibleDeprecationWarning
 
 
 class TestDeprecationWarning:

--- a/diffsims/tests/utils/test_fourier_transform.py
+++ b/diffsims/tests/utils/test_fourier_transform.py
@@ -160,9 +160,9 @@ def test_freq(shape, dX, rX, dY, rY):
             if dX[i] is not None:
                 assert abs(x[i].item(1) - x[i].item(0)) <= dX[i] + 1e-8
             if rY[i] is not None:
-                assert y[i].ptp() >= rY[i] - 1e-8
+                assert np.ptp(y[i]) >= rY[i] - 1e-8
         if rX[i] is not None:
-            assert x[i].ptp() >= rX[i] - 1e-8
+            assert np.ptp(x[i]) >= rX[i] - 1e-8
         if dY[i] is not None:
             assert abs(y[i].item(1) - y[i].item(0)) <= dY[i] + 1e-8
 

--- a/diffsims/utils/_deprecated.py
+++ b/diffsims/utils/_deprecated.py
@@ -35,6 +35,11 @@ import warnings
 
 import numpy as np
 
+if np.__version__ >= "2.0.0":
+    from numpy.exceptions import VisibleDeprecationWarning
+else:
+    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+
 
 class deprecated:
     """Decorator to mark deprecated functions with an informative
@@ -90,12 +95,14 @@ class deprecated:
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
-                action="always", category=np.VisibleDeprecationWarning, append=True
+                action="always",
+                category=VisibleDeprecationWarning,
+                append=True,
             )
             func_code = func.__code__
             warnings.warn_explicit(
                 message=msg,
-                category=np.VisibleDeprecationWarning,
+                category=VisibleDeprecationWarning,
                 filename=func_code.co_filename,
                 lineno=func_code.co_firstlineno + 1,
             )
@@ -143,12 +150,12 @@ class deprecated_argument:
                     kwargs[self.alternative] = kwargs.pop(self.name)
                 msg += f"See the documentation of `{func.__name__}()` for more details."
                 warnings.simplefilter(
-                    action="always", category=np.VisibleDeprecationWarning
+                    action="always", category=VisibleDeprecationWarning
                 )
                 func_code = func.__code__
                 warnings.warn_explicit(
                     message=msg,
-                    category=np.VisibleDeprecationWarning,
+                    category=VisibleDeprecationWarning,
                     filename=func_code.co_filename,
                     lineno=func_code.co_firstlineno + 1,
                 )

--- a/diffsims/utils/_deprecated.py
+++ b/diffsims/utils/_deprecated.py
@@ -33,12 +33,7 @@ import inspect
 from typing import Callable, Optional, Union
 import warnings
 
-import numpy as np
-
-if np.__version__ >= "2.0.0":
-    from numpy.exceptions import VisibleDeprecationWarning
-else:
-    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+from diffsims.constants import VisibleDeprecationWarning
 
 
 class deprecated:

--- a/diffsims/utils/discretise_utils.py
+++ b/diffsims/utils/discretise_utils.py
@@ -44,6 +44,7 @@ from numpy import (
     exp,
     prod,
 )
+import numpy as np
 from psutil import virtual_memory
 import numba
 
@@ -321,7 +322,7 @@ def rebin(x, loc, r, k, mem):
     else:
         r = r.copy()
     xmin = array([X.item(0) if X.size > 1 else -1e5 for X in x], dtype=x[0].dtype)
-    nbins = [int(ceil(x[i].ptp() / r[i])) + 1 for i in range(3)]
+    nbins = [int(ceil(np.ptp(x[i]) / r[i])) + 1 for i in range(3)]
     if prod(nbins) * 32 * 10 > mem:
         raise MemoryError
     Len = zeros(nbins, dtype="i4")


### PR DESCRIPTION
#### Description of the change
Support numpy 2.0.0

#### Progress of the PR
- [x] Pass tests with numpy 2.0.0

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.