### PR TITLE
Add simple progress bar to simulations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
           # Oldest supported version of main dependencies
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.5 numpy==1.17.3 orix==0.12.1 scipy==1.8 tqdm==4.9
+            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.5 numpy==1.17.3 orix==0.12.1 scipy==1.8 tqdm==4.61.2
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v4

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -37,6 +37,9 @@
       "orcid": "0000-0002-6402-9879"
     },
     {
+      "name": "Viljar Johan Femoen"
+    },
+    {
       "name":"Isabel Wood"
     },
     {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Progressbar for SimulationGenerator.calculate_diffraction2d in (#233)
 
 Changed
 -------

--- a/diffsims/generators/simulation_generator.py
+++ b/diffsims/generators/simulation_generator.py
@@ -206,7 +206,7 @@ class SimulationGenerator:
             rotate_iter = rotate
             if show_progressbar:
                 rotate_iter = tqdm(rotate_iter, desc=p.name, total=rotate.size)
-            
+
             for rot in rotate_iter:
                 # Calculate the reciprocal lattice vectors that intersect the Ewald sphere.
                 (

--- a/diffsims/generators/simulation_generator.py
+++ b/diffsims/generators/simulation_generator.py
@@ -19,7 +19,9 @@
 """Kinematic Diffraction Simulation Generator."""
 
 from typing import Union, Sequence
+
 import numpy as np
+from tqdm import tqdm
 
 from orix.quaternion import Rotation
 from orix.crystal_map import Phase
@@ -139,6 +141,7 @@ class SimulationGenerator:
         max_excitation_error: float = 1e-2,
         shape_factor_width: float = None,
         debye_waller_factors: dict = None,
+        show_progressbar: bool = False,
     ):
         """Calculates the diffraction pattern for one or more phases given a list
         of rotations for each phase.
@@ -166,6 +169,8 @@ class SimulationGenerator:
             control. If not set will be set equal to max_excitation_error.
         debye_waller_factors
             Maps element names to their temperature-dependent Debye-Waller factors.
+        show_progressbar
+            If True, display a progressbar. Defaults to False
 
         Returns
         -------
@@ -196,7 +201,13 @@ class SimulationGenerator:
                 include_zero_vector=with_direct_beam,
             )
             phase_vectors = []
-            for rot in rotate:
+
+            # Progress bar setup
+            rotate_iter = rotate
+            if show_progressbar:
+                rotate_iter = tqdm(rotate_iter, desc=p.name, total=rotate.size)
+            
+            for rot in rotate_iter:
                 # Calculate the reciprocal lattice vectors that intersect the Ewald sphere.
                 (
                     intersected_vectors,

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -14,6 +14,7 @@ credits = [
     "Ben Martineau",
     "Niels Cautaerts",
     "Joonatan Laulainen",
+    "Viljar Johan Femoen",
     "Isabel Wood",
     "Sean Collins",
     "Stef Smeets",


### PR DESCRIPTION
#### Description of the change
Adds a simple progress bar for simulations with `SimulationGenerator`

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### Minimal example of the bug fix or new feature
```python
from orix.quaternion import Rotation
from orix.crystal_map import Phase
from diffsims.generators.simulation_generator import SimulationGenerator
from diffpy.structure import Atom, Lattice, Structure

# Each phase gets its own progress bar
l = Lattice(1, 2, 3, 90, 100, 110)
atoms = [Atom("C", (0, 0, 0))]
s = Structure(atoms, l)
p1 = Phase("first phase", space_group=1, structure=s)
p2 = Phase("number 2", space_group=191, structure=s)

rots1 = Rotation.random(1000)
rots2 = Rotation.random(2000)

gen = SimulationGenerator()
sims = gen.calculate_diffraction2d(
    phase=[p1, p2],
    rotation=[rots1, rots2],
    show_progressbar=True,
)

>>> first phase: 100%|██████████| 1000/1000 [00:00<00:00, 2725.90it/s]
>>> number 2: 100%|██████████| 2000/2000 [00:01<00:00, 1909.23it/s]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.