### PR TITLE
Add option to have spot centers off pixel centers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ Unreleased
 Added
 -----
 - Progressbar for SimulationGenerator.calculate_diffraction2d in (#233)
-
+- Added ``fast`` parameter to ``Simulation2D.get_diffraction_pattern`` which allows
+  for sub pixel sampling of the diffraction pattern. This is useful for simulating
+  an accurate diffraction pattern. (#235)
 Changed
 -------
 
@@ -25,6 +27,8 @@ Removed
 
 Fixed
 -----
+- Fixed bug in masking logic for ``Simulation2D.polar_flatten`` in (#238)
+- Fixed a bug in 1D diffraction patterns for non-cubic lattices. (#238)
 
 2024-10-11 - version 0.6.1
 ==========================

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import numpy as np
+from numba import jit
 
 from numpy.random import default_rng
 from scipy import ndimage as ndi
@@ -31,6 +34,7 @@ __all__ = [
     "add_shot_noise",
     "add_shot_and_point_spread",
     "constrain_to_dynamic_range",
+    "get_pattern_from_pixel_coordinates_and_intensities",
 ]
 
 
@@ -243,3 +247,114 @@ def add_detector_offset(pattern, offset):
     """
     pattern = np.add(pattern, offset)
     return constrain_to_dynamic_range(pattern)
+
+
+def get_pattern_from_pixel_coordinates_and_intensities(
+    coordinates: np.ndarray,
+    intensities: np.ndarray,
+    shape: Tuple[int, int],
+    sigma: float,
+    clip_threshold: float = 1,
+) -> np.ndarray:
+    """Generate a diffraction pattern from spot pixel-coordinates and intensities,
+    using a gaussian blur.
+    This is subpixel-precise, meaning the coordinates can be floats.
+    Values less than `clip_threshold` are rounded down to 0 to simplify computation.
+
+    Parameters
+    ----------
+    coordinates : np.ndarray
+        Coordinates of reflections, in pixels. Shape (n, 2) or (n, 3). Can be floats
+    intensities : np.ndarray
+        Intensities of each reflection. Must have same same first dimension as `coordinates`
+    shape : tuple[int, int]
+        Output shape
+    sigma : float
+        For Gaussian blur
+    intensity_scale : float
+        Scale to multiply the final diffraction pattern with
+
+    Returns
+    -------
+    np.ndarray
+        dtype int
+
+    Notes
+    -----
+    Not all values below the clipping threshold are ignored.
+    The threshold is used to estimate a radius (box) around each reflection where the pixel intensity is greater than the threshold.
+    As the radius is rounded up and as the box is square rather than circular, some values below the threshold can be included.
+
+    When using float coordinates, the intensity is spread as if the edge was not there.
+    This is in line with what should be expected from a beam on the edge of the detector, as part of the beam is simply outside the detector area.
+    However, when using integer coordinates, the total intensity is preserved for the pixels in the pattern.
+    This means that the intensity contribution from parts of the beam which would hit outside the detector are now kept in the pattern.
+    Thus, reflections wich are partially outside the detector will have higher intensities than expected, when using integer coordinates.
+    """
+    if np.issubdtype(coordinates.dtype, np.integer):
+        # Much simpler with integer coordinates
+        coordinates = coordinates.astype(int)
+        out = np.zeros(shape)
+        # coordinates are xy(z), out array indices are yx.
+        out[coordinates[:, 1], coordinates[:, 0]] = intensities
+        out = add_shot_and_point_spread(out, sigma, shot_noise=False)
+        return out
+
+    # coordinates of each pixel in the output, such that the final axis is yx coordinates
+    inds = np.transpose(np.indices(shape), (1, 2, 0))
+    return _subpixel_gaussian(
+        coordinates,
+        intensities,
+        inds,
+        shape,
+        sigma,
+        clip_threshold,
+    )
+
+
+@jit(
+    nopython=True
+)  # Not parallel, we might get a race condition with overlapping spots
+def _subpixel_gaussian(
+    coordinates: np.ndarray,
+    intensities: np.ndarray,
+    inds: np.ndarray,
+    shape: Tuple[int, int],
+    sigma: float,
+    clip_threshold: float = 1,
+) -> np.ndarray:
+    out = np.zeros(shape)
+
+    # Pre-calculate the constants
+    prefactor = 1 / (2 * np.pi * sigma**2)
+    exp_prefactor = -1 / (2 * sigma**2)
+
+    for i in range(intensities.size):
+        # Reverse since coords are xy, but indices are yx
+        coord = coordinates[i][:2][::-1]
+        intens = intensities[i]
+
+        # The gaussian is expensive to evaluate for all pixels and spots.
+        # Therefore, we limit the calculations to a box around each reflection where the intensity is above a threshold.
+        # Formula found by inverting the gaussian
+        radius = np.sqrt(np.log(clip_threshold / (prefactor * intens)) / exp_prefactor)
+
+        if np.isnan(radius):
+            continue
+        slic = (
+            slice(
+                max(0, int(np.ceil(coord[0] - radius))),
+                min(shape[0], int(np.floor(coord[0] + radius + 1))),
+            ),
+            slice(
+                max(0, int(np.ceil(coord[1] - radius))),
+                min(shape[1], int(np.floor(coord[1] + radius + 1))),
+            ),
+        )
+        # Calculate the values of the Gaussian manually
+        out[slic] += (
+            intens
+            * prefactor
+            * np.exp(exp_prefactor * np.sum((inds[slic] - coord) ** 2, axis=-1))
+        )
+    return out

--- a/diffsims/pattern/detector_functions.py
+++ b/diffsims/pattern/detector_functions.py
@@ -322,7 +322,7 @@ def _subpixel_gaussian(
     shape: Tuple[int, int],
     sigma: float,
     clip_threshold: float = 1,
-) -> np.ndarray:
+) -> np.ndarray:  # pragma: no cover
     out = np.zeros(shape)
 
     # Pre-calculate the constants

--- a/diffsims/simulations/simulation2d.py
+++ b/diffsims/simulations/simulation2d.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Sequence, TYPE_CHECKING, Any
+from typing import Union, Sequence, Tuple, TYPE_CHECKING, Any
 import copy
 
 import numpy as np
@@ -27,7 +27,9 @@ from orix.quaternion import Rotation
 from orix.vector import Vector3d
 
 from diffsims.crystallography._diffracting_vector import DiffractingVector
-from diffsims.pattern.detector_functions import add_shot_and_point_spread
+from diffsims.pattern.detector_functions import (
+    get_pattern_from_pixel_coordinates_and_intensities,
+)
 
 # to avoid circular imports
 if TYPE_CHECKING:  # pragma: no cover
@@ -354,12 +356,15 @@ class Simulation2D:
 
     def get_diffraction_pattern(
         self,
-        shape=None,
-        sigma=10,
-        direct_beam_position=None,
-        in_plane_angle=0,
-        calibration=0.01,
-        mirrored=False,
+        shape: Tuple[int, int] = None,
+        sigma: float = 10,
+        direct_beam_position: Tuple[int, int] = None,
+        in_plane_angle: float = 0,
+        calibration: float = 0.01,
+        mirrored: bool = False,
+        fast: bool = True,
+        normalize: bool = True,
+        fast_clip_threshold: float = 1,
     ):
         """Returns the diffraction data as a numpy array with
         two-dimensional Gaussians representing each diffracted peak. Should only
@@ -379,11 +384,19 @@ class Simulation2D:
         mirrored: bool, optional
             Whether the pattern should be flipped over the x-axis,
             corresponding to the inverted orientation
-
+        fast: bool, optional
+            Whether to speed up calculations by rounding spot coordinates down to integer pixel
+        normalize: bool, optional
+            Whether to normalize the pattern to values between 0 and 1
+        fast_clip_threshold: float, optional
+            Only used when `fast` is False.
+            Pixel intensity threshold, such that pixels which would be below this value are ignored.
+            Thresholding performed before possible normalization.
+            See diffsims.pattern.detector_functions.get_pattern_from_pixel_coordinates_and_intensities for details.
         Returns
         -------
         diffraction-pattern : numpy.array
-            The simulated electron diffraction pattern, normalised.
+            The simulated electron diffraction pattern, normalized by default.
 
         Notes
         -----
@@ -392,7 +405,13 @@ class Simulation2D:
         the order of 0.5nm and the default size and sigma are used.
         """
         if direct_beam_position is None:
-            direct_beam_position = (shape[1] // 2, shape[0] // 2)
+            # Use subpixel-precise center if possible
+            if fast or np.issubdtype(
+                self.get_current_coordinates().data.dtype, np.integer
+            ):
+                direct_beam_position = (shape[1] // 2, shape[0] // 2)
+            else:
+                direct_beam_position = ((shape[1] - 1) / 2, (shape[0] - 1) / 2)
         transformed = self._get_transformed_coordinates(
             in_plane_angle,
             direct_beam_position,
@@ -406,17 +425,21 @@ class Simulation2D:
             & (transformed.data[:, 1] >= 0)
             & (transformed.data[:, 1] < shape[0])
         )
-        spot_coords = transformed.data[in_frame].astype(int)
-
+        spot_coords = transformed.data[in_frame]
+        if fast:
+            spot_coords = spot_coords.astype(int)
         spot_intens = transformed.intensity[in_frame]
-        pattern = np.zeros(shape)
+
         # checks that we have some spots
         if spot_intens.shape[0] == 0:
-            return pattern
-        else:
-            pattern[spot_coords[:, 0], spot_coords[:, 1]] = spot_intens
-            pattern = add_shot_and_point_spread(pattern.T, sigma, shot_noise=False)
-        return np.divide(pattern, np.max(pattern))
+            return np.zeros(shape)
+
+        pattern = get_pattern_from_pixel_coordinates_and_intensities(
+            spot_coords, spot_intens, shape, sigma, fast_clip_threshold
+        )
+        if normalize:
+            pattern = np.divide(pattern, np.max(pattern))
+        return pattern
 
     @property
     def num_phases(self):

--- a/diffsims/simulations/simulation2d.py
+++ b/diffsims/simulations/simulation2d.py
@@ -364,7 +364,7 @@ class Simulation2D:
         mirrored: bool = False,
         fast: bool = True,
         normalize: bool = True,
-        fast_clip_threshold: float = 1,
+        clip_threshold: float = 1,
     ):
         """Returns the diffraction data as a numpy array with
         two-dimensional Gaussians representing each diffracted peak. Should only
@@ -388,7 +388,7 @@ class Simulation2D:
             Whether to speed up calculations by rounding spot coordinates down to integer pixel
         normalize: bool, optional
             Whether to normalize the pattern to values between 0 and 1
-        fast_clip_threshold: float, optional
+        clip_threshold: float, optional
             Only used when `fast` is False.
             Pixel intensity threshold, such that pixels which would be below this value are ignored.
             Thresholding performed before possible normalization.
@@ -435,7 +435,7 @@ class Simulation2D:
             return np.zeros(shape)
 
         pattern = get_pattern_from_pixel_coordinates_and_intensities(
-            spot_coords, spot_intens, shape, sigma, fast_clip_threshold
+            spot_coords, spot_intens, shape, sigma, clip_threshold
         )
         if normalize:
             pattern = np.divide(pattern, np.max(pattern))

--- a/diffsims/tests/simulations/test_simulations2d.py
+++ b/diffsims/tests/simulations/test_simulations2d.py
@@ -130,6 +130,55 @@ class TestSingleSimulation:
         copied = single_simulation.deepcopy()
         assert copied is not single_simulation
 
+    def test_get_diffraction_pattern_fast_vs_slow(self, al_phase):
+        gen = SimulationGenerator()
+        rot = Rotation.identity()
+        xyz = np.asarray([[0, 0, 0]])
+        i = np.array([30])
+        integer_coords = DiffractingVector(
+            phase=al_phase, xyz=xyz.astype(int), intensity=i
+        )
+        float_coords = DiffractingVector(
+            phase=al_phase, xyz=xyz.astype(float), intensity=i
+        )
+        int_sim = Simulation2D(
+            phases=al_phase,
+            simulation_generator=gen,
+            coordinates=integer_coords,
+            rotations=rot,
+        )
+        float_sim = Simulation2D(
+            phases=al_phase,
+            simulation_generator=gen,
+            coordinates=float_coords,
+            rotations=rot,
+        )
+        sim_kwargs = dict(
+            shape=(11, 11),  # This shape has a center directly at a pixel
+            sigma=1,
+            calibration=1,
+            normalize=False,
+            fast_clip_threshold=0.01,
+        )
+        # Check that fast/slow are the same when coordinates are dtype int
+        fast = int_sim.get_diffraction_pattern(fast=True, **sim_kwargs)
+        slow = int_sim.get_diffraction_pattern(fast=False, **sim_kwargs)
+        # Should be exactly equal
+        assert np.array_equal(fast, slow)
+
+        # Check that float coords are the same too, when the center is in a pixel
+        float_fast = float_sim.get_diffraction_pattern(fast=True, **sim_kwargs)
+        float_slow = float_sim.get_diffraction_pattern(fast=False, **sim_kwargs)
+        assert np.allclose(float_fast, fast)
+        assert np.all((float_slow - float_fast) < sim_kwargs["fast_clip_threshold"])
+
+        # Change the size, now the center is between pixels.
+        # Slow should reflect this
+        sim_kwargs["shape"] = (10, 10)
+        float_fast = float_sim.get_diffraction_pattern(fast=True, **sim_kwargs)
+        float_slow = float_sim.get_diffraction_pattern(fast=False, **sim_kwargs)
+        assert not np.allclose(float_fast, float_slow)
+
 
 class TestSimulationInitFailures:
     def test_different_size(self, al_phase):

--- a/diffsims/tests/simulations/test_simulations2d.py
+++ b/diffsims/tests/simulations/test_simulations2d.py
@@ -158,7 +158,7 @@ class TestSingleSimulation:
             sigma=1,
             calibration=1,
             normalize=False,
-            fast_clip_threshold=0.01,
+            clip_threshold=0.01,
         )
         # Check that fast/slow are the same when coordinates are dtype int
         fast = int_sim.get_diffraction_pattern(fast=True, **sim_kwargs)
@@ -170,7 +170,7 @@ class TestSingleSimulation:
         float_fast = float_sim.get_diffraction_pattern(fast=True, **sim_kwargs)
         float_slow = float_sim.get_diffraction_pattern(fast=False, **sim_kwargs)
         assert np.allclose(float_fast, fast)
-        assert np.all((float_slow - float_fast) < sim_kwargs["fast_clip_threshold"])
+        assert np.all((float_slow - float_fast) < sim_kwargs["clip_threshold"])
 
         # Change the size, now the center is between pixels.
         # Slow should reflect this

--- a/diffsims/utils/fourier_transform.py
+++ b/diffsims/utils/fourier_transform.py
@@ -216,7 +216,7 @@ try:  # pragma: no cover
         )
         return plan, plan.input_array
 
-except ImportError:
+except ImportError:  # pragma: no cover
     # Only scipy has a next_fast_len, usually numpy is a little faster
     # (note they are not identical)
     from scipy.fftpack import fftn, ifftn, ifftshift, fftshift, next_fast_len
@@ -224,7 +224,7 @@ except ImportError:
 
     _fftn, _ifftn = fftn, ifftn
 
-    def plan_fft(A, n=None, axis=None, norm=None, **_):
+    def plan_fft(A, n=None, axis=None, norm=None, **_):  # pragma: no cover
         """
         Plans an fft for repeated use. Parameters are the same as for `pyfftw`'s `fftn`
         which are, where possible, the same as the `numpy` equivalents.


### PR DESCRIPTION
#### Description of the change
Previously, Simulation2d.get_diffraction_pattern rounded coordinates down to nearest pixel in the output pattern, before adding a gaussian blur.
This PR implements a more manual gaussian blurring, evaluating the gaussian without assuming integer spot coordinates instead of using convolution.
This gives more accurate spot positions, which is important when using these patterns in external analysis tools.
It is slower, but using numba made it only around 20% slower (as opposed to 800% slower without).

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### Minimal example of the bug fix or new feature
```python
# Setup
from diffpy.structure import Structure, Atom, Lattice
from orix.crystal_map import Phase
from diffsims.generators.simulation_generator import SimulationGenerator

l = Lattice(10, 10, 10, 90, 90, 90)
a = [Atom("Au", (0, 0, 0))]
s = Structure(a, l)

p = Phase(structure=s, space_group=1)

gen = SimulationGenerator()
sim = gen.calculate_diffraction2d(p)
```
Performance analysis:
```
%%timeit
sim.get_diffraction_pattern(shape=(100,100), sigma=1, fast=True)
```
205 µs ± 4.61 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
%%timeit
sim.get_diffraction_pattern(shape=(100,100), sigma=1, fast=False)
```
250 µs ± 2.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

New is around 25% slower.

Qualitative difference in resulting plots:
```python
from matplotlib import pyplot as plt
plt.figure()
plt.subplot(1, 2, 1)
kwargs = dict(
    shape=(10, 10), 
    sigma=1, 
    normalize=False,
    fast_clip_threshold=0.1,
    calibration=0.001, # Very small calibration = only direct beam
)
fast = sim.get_diffraction_pattern(fast=True, **kwargs)
plt.imshow(fast, vmax=20)
plt.subplot(1, 2, 2)
slow = sim.get_diffraction_pattern(fast=False, **kwargs)
plt.imshow(slow, vmax=20)
```
![image](https://github.com/user-attachments/assets/507fcca4-aac7-4fc0-b6ff-c4598299211f)

In the example above, since the shape is 10x10, the center is not at a pixel coordinate, but at (4.5, 4.5). This is rounded to (5, 5) in the fast (current) mode.

Note that there is a bug where the direct beam is added twice to the simulations. For the fast mode, this is fine, as the intensity of each spot is set rather than summed (before blurring). For the new, however, the direct beam is twice as intense as it should. This is fixed in #232.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.