### PR TITLE
Support CIF files from ICSD with atom type symbols like `Au0+`

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -64,6 +64,11 @@
       "name":"Tina Bergh"
     },
     {
+      "name":"Dieter Weber",
+      "orcid": "0000-0001-6635-9567",
+      "affiliation": "Forschungszentrum Jülich"
+    },
+    {
       "name":"Tomas Ostasevicius"
     },
     {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0>`_
 this project tries its best to adhere to
 `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
+Added
+-----
+
+- Support for wider range of `CIF atom type symbols
+  <https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html>`_,
+  notably element symbol followed by oxidation number as found in CIF files
+  recently pulled from `ICSD <https://icsd.fiz-karlsruhe.de/>`_ (#245).
+
 2025-06-02 - version 0.7.0
 ==========================
 

--- a/diffsims/release_info.py
+++ b/diffsims/release_info.py
@@ -23,6 +23,7 @@ credits = [
     "Jedrzej Morzy",
     "Endre Jacobsen",
     "Tina Bergh",
+    "Dieter Weber",
     "Tomas Ostasevicius",
     "Eirik Opheim",
 ]

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with diffsims.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 import numpy as np
 
 # List of elements Z = 1-118
@@ -140,6 +142,28 @@ ATOMIC_SCATTERING_PARAMETERS_DOYLETURNER = np.array([
 # fmt: on
 
 
+def get_element(atom_type_symbol):
+    """Extract element symbol from _atom_type_symbol CIF key
+
+    See https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html
+    for specification.
+
+    Parameters
+    ----------
+    atom_type_symbol : str
+        Symbol following the specification of _atom_type_symbol CIF key
+
+    Returns
+    -------
+
+    element : str
+        Alphabetic part of atom_type_symbol, notably without oxidation state.
+        Usually the element name, but not guaranteed by the specification.
+    """
+    reg = '^(?P<element>[A-Za-z]*)'
+    return re.match(reg, atom_type_symbol).group('element')
+
+
 def get_atomic_scattering_parameters(element, unit=None):
     """Return the eight atomic scattering parameters a_1-4, b_1-4 for
     elements with atomic numbers Z = 1-98 from Table 12.1 in
@@ -203,8 +227,9 @@ def get_element_id_from_string(element_str):
     element_id : int
         Integer ID in the periodic table of elements.
     """
+    element = get_element(element_str)
     element2periodic = dict(zip(ELEMENTS[:N_ELEMENTS], np.arange(1, N_ELEMENTS)))
-    element_id = element2periodic[element_str.lower()]
+    element_id = element2periodic[element.lower()]
     return element_id
 
 

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -157,8 +157,8 @@ def get_element(atom_type_symbol):
     -------
 
     element : str
-        Alphabetic part of atom_type_symbol, notably without oxidation state.
-        Usually the element name, but not guaranteed by the specification.
+        Alphabetic head of atom_type_symbol, notably without oxidation state.
+        Usually an element symbol, but not guaranteed by the specification.
     """
     reg = "^(?P<element>[A-Za-z]*)"
     return re.match(reg, atom_type_symbol).group("element")
@@ -215,12 +215,17 @@ def get_atomic_scattering_parameters(element, unit=None):
 
 def get_element_id_from_string(element_str):
     r"""Get periodic element ID for elements :math:`Z` = 1-98 from
-    one-two letter string.
+    element symbol.
 
     Parameters
     ----------
     element_str : str
-        One-two letter string.
+        String starting with an element symbol, optionally delimited from other
+        following characters by a non-alphabetic character. Only the element
+        symbol is evaluated. In particular, compatible with common atom type
+        symbols in CIF files that often start with an element symbol followed by
+        e.g. an optional oxidation number, although this is not guaranteed:
+        https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html
 
     Returns
     -------

--- a/diffsims/structure_factor/atomic_scattering_parameters.py
+++ b/diffsims/structure_factor/atomic_scattering_parameters.py
@@ -160,8 +160,8 @@ def get_element(atom_type_symbol):
         Alphabetic part of atom_type_symbol, notably without oxidation state.
         Usually the element name, but not guaranteed by the specification.
     """
-    reg = '^(?P<element>[A-Za-z]*)'
-    return re.match(reg, atom_type_symbol).group('element')
+    reg = "^(?P<element>[A-Za-z]*)"
+    return re.match(reg, atom_type_symbol).group("element")
 
 
 def get_atomic_scattering_parameters(element, unit=None):

--- a/diffsims/tests/structure_factor/test_structure_factor.py
+++ b/diffsims/tests/structure_factor/test_structure_factor.py
@@ -34,7 +34,10 @@ nickel = Phase(
     space_group=225,
     structure=Structure(
         lattice=Lattice(3.5236, 3.5236, 3.5236, 90, 90, 90),
-        atoms=[Atom(xyz=[0, 0, 0], atype="Ni", Uisoequiv=0.006332)],
+        # Atom specified in a way found in CIF files from ICSD
+        # See also
+        # https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html
+        atoms=[Atom(xyz=[0, 0, 0], atype="Ni0+", Uisoequiv=0.006332)],
     ),
 )
 ferrite = Phase(

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -20,6 +20,9 @@ import pytest
 import numpy as np
 import diffpy
 
+from diffpy.structure import Atom, Lattice, Structure
+from orix.crystal_map import Phase
+
 
 from diffsims.utils.sim_utils import (
     get_electron_wavelength,
@@ -347,4 +350,45 @@ def test_get_kinematical_intensities(default_structure, scattering_params, answe
         prefactor=multiplicites,
         scattering_params=scattering_params,
     )
+    np.testing.assert_array_almost_equal(i_hkls, ([answer]), decimal=4)
+
+
+# Copied from Nickel, with unknown element Unobtainium
+# Arbitrary strings can be found in CIF files, see
+# https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html
+unobtainium = Phase(
+    space_group=225,
+    structure=Structure(
+        lattice=Lattice(3.5236, 3.5236, 3.5236, 90, 90, 90),
+        # Note that the standard explicitly shows "NiFe" and "dummy"
+        # as examples
+        atoms=[Atom(xyz=[0, 0, 0], atype="UnOb", Uisoequiv=0.006332)],
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "scattering_params, answer",
+    [
+        ("lobato", 0.),
+        (None, 1.0),
+    ],
+)
+def test_get_kinematical_intensities_unknown(scattering_params, answer):
+    latt = unobtainium.structure.lattice
+    reciprocal_lattice = latt.reciprocal()
+    reciprocal_radius = 0.2
+    unique_hkls, multiplicites, g_hkls = get_intensities_params(
+        reciprocal_lattice, reciprocal_radius
+    )
+    g_hkls_array = np.asarray(g_hkls)
+    # Debatable if this should actually be an error and not just a warning
+    with pytest.warns(UserWarning, match='not found in scattering parameter library.'):
+        i_hkls = get_kinematical_intensities(
+            unobtainium.structure,
+            g_indices=unique_hkls,
+            g_hkls_array=g_hkls_array,
+            prefactor=multiplicites,
+            scattering_params=scattering_params,
+        )
     np.testing.assert_array_almost_equal(i_hkls, ([answer]), decimal=4)

--- a/diffsims/tests/utils/test_sim_utils.py
+++ b/diffsims/tests/utils/test_sim_utils.py
@@ -370,7 +370,7 @@ unobtainium = Phase(
 @pytest.mark.parametrize(
     "scattering_params, answer",
     [
-        ("lobato", 0.),
+        ("lobato", 0.0),
         (None, 1.0),
     ],
 )
@@ -383,7 +383,7 @@ def test_get_kinematical_intensities_unknown(scattering_params, answer):
     )
     g_hkls_array = np.asarray(g_hkls)
     # Debatable if this should actually be an error and not just a warning
-    with pytest.warns(UserWarning, match='not found in scattering parameter library.'):
+    with pytest.warns(UserWarning, match="not found in scattering parameter library."):
         i_hkls = get_kinematical_intensities(
             unobtainium.structure,
             g_indices=unique_hkls,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ exec(open("diffsims/release_info.py").read())  # grab version info
 # fmt: off
 extra_feature_requirements = {
     "doc": [
-        "numpydoc",
+        # Restriction due to https://github.com/pyxem/orix/issues/570
+        "numpydoc               != 1.9.0",
         "pydata-sphinx-theme",
         "sphinx                 >= 3.0.2",
         "sphinx-design",


### PR DESCRIPTION
A recent CIF file pulled from https://icsd.fiz-karlsruhe.de/ for collection code 163723 contained the atom type symbol "Au0+" instead of just Au. This lead to empty diffraction patterns.

With this change only the first alphabetical
part of the atom type symbol is used as an element, and a warning is emitted if unknown elements are encountered.

See https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html for the definition of the atom type symbol.

It can be debated if unrecognized atom type symbols should actually be a hard error since the current
code will quietly zero the contribution of sites with unknown atom types, which may lead to plausible but wrong diffraction patterns if recognized and unrecognized atom type symbols are mixed in a CIF file.

#### Description of the change


#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right)

#### Minimal example of the bug fix or new feature

[EntryWithCollCode163723.cif.txt](https://github.com/user-attachments/files/22743643/EntryWithCollCode163723.cif.txt)

```python
from diffpy.structure import loadStructure
from diffsims.generators.simulation_generator import SimulationGenerator
from orix.quaternion import Rotation
from orix.crystal_map import Phase
gen = SimulationGenerator(
    accelerating_voltage=300,
)
rot = Rotation.from_axes_angles(
    [1, 0, 0], 0, degrees=True
)
structure = loadStructure('EntryWithCollCode163723.cif')
p = Phase(structure=structure, space_group=225)
sim = gen.calculate_diffraction2d(phase=p, rotation=rot)
# Previously gave you an empty list
print(sim.coordinates)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.